### PR TITLE
Fix set_client_verify(false) not disabling hostname verification

### DIFF
--- a/.release-notes/fix-client-verify-hostname.md
+++ b/.release-notes/fix-client-verify-hostname.md
@@ -1,0 +1,5 @@
+## Fix set_client_verify(false) not disabling hostname verification
+
+When `set_client_verify(false)` was called on an `SSLContext`, the OpenSSL peer certificate verification was correctly disabled, but hostname verification still ran when a hostname was passed to `SSLContext.client(hostname)`. This meant connections would fail if the server certificate didn't have a SAN or CN matching the hostname, even with verification explicitly disabled.
+
+Hostname verification is now correctly skipped when `set_client_verify(false)` is set.

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -43,6 +43,7 @@ class SSL
   to any transport layer.
   """
   let _hostname: String
+  let _verify: Bool
   var _ssl: Pointer[_SSL]
   var _input: Pointer[_BIO] tag
   var _output: Pointer[_BIO] tag
@@ -61,6 +62,7 @@ class SSL
     """
     if ctx.is_null() then error end
     _hostname = hostname
+    _verify = verify
 
     _ssl = @SSL_new(ctx)
     if _ssl.is_null() then error end
@@ -259,7 +261,7 @@ class SSL
     """
     Verify that the certificate is valid for the given hostname.
     """
-    if _hostname.size() > 0 then
+    if _verify and (_hostname.size() > 0) then
       let cert = ifdef "openssl_3.0.x" then
         @SSL_get1_peer_certificate(_ssl)
       elseif "openssl_1.1.x" or "openssl_0.9.0" then


### PR DESCRIPTION
When `set_client_verify(false)` was called on an `SSLContext`, OpenSSL peer certificate verification was correctly disabled via `SSL_VERIFY_NONE`, but the application-level hostname verification in `_verify_hostname()` still ran unconditionally. This caused connections to fail when the server certificate didn't have a SAN or CN matching the hostname, even though verification was explicitly disabled.

The fix stores the `verify` flag in the `SSL` class and skips hostname verification when it is false. SNI (`SSL_set_tlsext_host_name`) is unaffected — the server still gets told which hostname the client wants, which is independent of whether the client validates the certificate.

Closes #10