### PR TITLE
Add HMAC-SHA-256, PBKDF2-SHA-256, and RandBytes primitives

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,5 @@
 CHANGELOG.md
 CODE_OF_CONDUCT.md
+CLAUDE.md
+.claude/
 .release-notes/

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,23 @@
+## Add HMAC-SHA-256 primitive
+
+`HmacSha256` computes HMAC message authentication codes using SHA-256 (RFC 2104):
+
+```pony
+let mac = HmacSha256("secret-key", "Hello, World!")
+```
+
+## Add PBKDF2-SHA-256 primitive
+
+`Pbkdf2Sha256` derives keys from passwords using PBKDF2 with HMAC-SHA-256 (RFC 2898). Requires OpenSSL 1.1.x or 3.0.x:
+
+```pony
+let key = Pbkdf2Sha256("password", "salt", 4096, 32)?
+```
+
+## Add RandBytes primitive
+
+`RandBytes` generates cryptographically secure random bytes:
+
+```pony
+let nonce = RandBytes(24)?
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- Add HMAC-SHA-256 primitive ([PR #16](https://github.com/ponylang/ssl/pull/16))
+- Add PBKDF2-SHA-256 primitive ([PR #16](https://github.com/ponylang/ssl/pull/16))
+- Add RandBytes primitive ([PR #16](https://github.com/ponylang/ssl/pull/16))
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # SSL Package
 
-Pony bindings for OpenSSL and LibreSSL, providing SSL networking (`ssl/net`) and cryptographic hashing (`ssl/crypto`).
+Pony bindings for OpenSSL and LibreSSL, providing SSL networking (`ssl/net`) and cryptographic primitives (`ssl/crypto`).
 
 ## Building and Testing
 
@@ -53,6 +53,9 @@ Every ifdef chain must end with `compile_error` to catch missing defines at comp
 | `ssl/net/ssl.pony` | SSL session — handshake, read/write, certificate verification |
 | `ssl/net/x509.pony` | Certificate name extraction and hostname matching |
 | `ssl/crypto/digest.pony` | Hash digests (MD5, SHA family, SHAKE) via EVP API |
+| `ssl/crypto/hmac_sha256.pony` | HMAC-SHA-256 message authentication (RFC 2104) |
+| `ssl/crypto/pbkdf2_sha256.pony` | PBKDF2 key derivation with HMAC-SHA-256 (RFC 2898, OpenSSL 1.1.x+ only) |
+| `ssl/crypto/rand_bytes.pony` | Cryptographically secure random byte generation |
 
 ## Known Issues
 

--- a/ssl/crypto/crypto.pony
+++ b/ssl/crypto/crypto.pony
@@ -1,7 +1,12 @@
 """
-The crypto package includes a variety of common cryptographic algorithms
-and functions often useful in cryptographic code for their use in information
-security.
+The crypto package provides cryptographic primitives built on OpenSSL:
+
+* One-shot hash functions (`MD5`, `SHA256`, etc.) and streaming digests
+  (`Digest`)
+* HMAC message authentication (`HmacSha256`)
+* PBKDF2 key derivation (`Pbkdf2Sha256`, requires OpenSSL 1.1.x or 3.0.x)
+* Cryptographically secure random bytes (`RandBytes`)
+* Constant-time comparison (`ConstantTimeCompare`)
 """
 
 use @pony_ctx[Pointer[None]]()

--- a/ssl/crypto/hmac_sha256.pony
+++ b/ssl/crypto/hmac_sha256.pony
@@ -1,0 +1,30 @@
+use "path:/usr/local/opt/libressl/lib" if osx and x86
+use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
+use "lib:crypto"
+
+use @HMAC[Pointer[U8]](
+  evp_md: Pointer[_EVPMD],
+  key: Pointer[U8] tag, key_len: I32,
+  data: Pointer[U8] tag, data_len: USize,
+  md: Pointer[U8] tag, md_len: Pointer[U32])
+
+primitive HmacSha256
+  """
+  Compute HMAC using SHA-256 as the hash function, as defined in RFC 2104.
+
+  Returns a 32-byte message authentication code.
+
+  ```pony
+  let mac = HmacSha256("secret-key", "Hello, World!")
+  ```
+  """
+  fun tag apply(key: ByteSeq, data: ByteSeq): Array[U8] val =>
+    recover
+      // Use Array.init instead of pony_alloc + from_cpointer to avoid
+      // intermittent GC buffer corruption. See ponyc#4831.
+      let size: USize = 32
+      let arr = Array[U8].init(0, size)
+      @HMAC(@EVP_sha256(), key.cpointer(), key.size().i32(),
+        data.cpointer(), data.size(), arr.cpointer(), Pointer[U32])
+      arr
+    end

--- a/ssl/crypto/pbkdf2_sha256.pony
+++ b/ssl/crypto/pbkdf2_sha256.pony
@@ -1,0 +1,45 @@
+use "path:/usr/local/opt/libressl/lib" if osx and x86
+use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
+use "lib:crypto"
+
+use @PKCS5_PBKDF2_HMAC[I32](
+  pass: Pointer[U8] tag, passlen: I32,
+  salt: Pointer[U8] tag, saltlen: I32, iter: I32,
+  digest: Pointer[_EVPMD],
+  keylen: I32, out: Pointer[U8] tag) if "openssl_1.1.x" or "openssl_3.0.x"
+
+primitive Pbkdf2Sha256
+  """
+  Derive a key from a password using PBKDF2 with HMAC-SHA-256 as the PRF,
+  as defined in RFC 2898.
+
+  Returns a key of the requested length, or raises an error if the derivation
+  fails (e.g., zero iterations).
+
+  Requires OpenSSL 1.1.x or 3.0.x. Not available on the legacy 0.9.0 path.
+
+  ```pony
+  let key = Pbkdf2Sha256("password", "salt", 4096, 32)?
+  ```
+  """
+  fun tag apply(password: ByteSeq, salt: ByteSeq, iterations: U32,
+    key_length: USize): Array[U8] val ?
+  =>
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+      recover
+        let arr = Array[U8].init(0, key_length)
+        let rc = @PKCS5_PBKDF2_HMAC(
+          password.cpointer(), password.size().i32(),
+          salt.cpointer(), salt.size().i32(),
+          iterations.i32(),
+          @EVP_sha256(),
+          key_length.i32(),
+          arr.cpointer())
+        if rc != 1 then error end
+        arr
+      end
+    elseif "openssl_0.9.0" then
+      compile_error "Pbkdf2Sha256 requires OpenSSL 1.1.x or 3.0.x"
+    else
+      compile_error "You must select an SSL version to use."
+    end

--- a/ssl/crypto/rand_bytes.pony
+++ b/ssl/crypto/rand_bytes.pony
@@ -1,0 +1,25 @@
+use "path:/usr/local/opt/libressl/lib" if osx and x86
+use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
+use "lib:crypto"
+
+use @RAND_bytes[I32](buf: Pointer[U8] tag, num: I32)
+
+primitive RandBytes
+  """
+  Generate cryptographically secure random bytes using OpenSSL's CSPRNG.
+
+  Returns an array of the requested number of random bytes, or raises an
+  error if the CSPRNG cannot generate secure output (e.g., insufficient
+  entropy during early system startup).
+
+  ```pony
+  let nonce = RandBytes(24)?
+  ```
+  """
+  fun tag apply(size: USize): Array[U8] val ? =>
+    recover
+      let arr = Array[U8].init(0, size)
+      let rc = @RAND_bytes(arr.cpointer(), size.i32())
+      if rc != 1 then error end
+      arr
+    end


### PR DESCRIPTION
Adds three new cryptographic primitives to `ssl/crypto` as prerequisites
for SCRAM-SHA-256 authentication in ponylang/postgres (see
ponylang/postgres#83 Discussion Point 1):

- **HmacSha256** — One-shot HMAC-SHA-256 (RFC 2104) wrapping OpenSSL's
  `HMAC()`. Non-partial, matching the existing hash primitive convention.
- **Pbkdf2Sha256** — PBKDF2 key derivation with HMAC-SHA-256 PRF
  (RFC 2898) wrapping `PKCS5_PBKDF2_HMAC()`. Partial. Requires
  OpenSSL 1.1.x or 3.0.x; compile_error on 0.9.0.
- **RandBytes** — Cryptographically secure random bytes wrapping
  `RAND_bytes()`. Partial.

Tests include RFC 4231 vectors (HMAC), RFC 7914 vectors (PBKDF2),
SCRAM-SHA-256 intermediate values from RFC 7677, and PonyCheck property
tests for output length, determinism, and non-constancy.

Design: #15