### PR TITLE
Add first-class LibreSSL support

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Test
-        run: make test config=debug ssl=0.9.0
+        run: make test config=debug ssl=libressl
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Test
-        run: make test config=debug ssl=0.9.0
+        run: make test config=debug ssl=libressl
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Test
-        run: make test config=debug ssl=0.9.0
+        run: make test config=debug ssl=libressl
 
   test-libressl-4-vs-ponyc-release:
     name: LibreSSL 4.x with most recent ponyc release
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Test
-        run: make test config=debug ssl=0.9.0
+        run: make test config=debug ssl=libressl
 
   test-openssl-1-vs-ponyc-release:
     name: OpenSSL 1.x with most recent ponyc release

--- a/.release-notes/add-libressl-define.md
+++ b/.release-notes/add-libressl-define.md
@@ -1,0 +1,5 @@
+## Add first-class LibreSSL support
+
+LibreSSL users previously had to build with `-Dopenssl_0.9.0`, which forced LibreSSL through a code path designed for ancient OpenSSL. This silently disabled ALPN negotiation, PBKDF2 key derivation, and the modern EVP/init APIs that LibreSSL supports.
+
+LibreSSL now has its own define. Projects that build against LibreSSL should switch from `-Dopenssl_0.9.0` to `-Dlibressl`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,20 @@ SSL version is **required**. Valid values:
 |---|---|---|
 | `3.0.x` | `-Dopenssl_3.0.x` | OpenSSL 3.x |
 | `1.1.x` | `-Dopenssl_1.1.x` | OpenSSL 1.1.x |
-| `0.9.0` | `-Dopenssl_0.9.0` | Legacy (was used for LibreSSL, pending removal via #9) |
-| `libressl` | `-Dlibressl` | LibreSSL (pending, tracked in #9) |
+| `0.9.0` | `-Dopenssl_0.9.0` | Legacy (pending removal via #9 PR 2) |
+| `libressl` | `-Dlibressl` | LibreSSL |
 
 Windows (`make.ps1`) always builds against LibreSSL. The define is hardcoded on line 70.
+
+### LibreSSL API Divergences from OpenSSL 1.1.x
+
+LibreSSL's API is mostly OpenSSL 1.1.x compatible, with five differences that require separate code paths:
+
+1. **`sk_pop`/`sk_free`** — LibreSSL uses old names (no `OPENSSL_` prefix)
+2. **`SSL_CTX_set_options`/`SSL_CTX_clear_options`** — macros in LibreSSL, not real functions. Pony FFI can't call macros, so LibreSSL uses `SSL_CTX_ctrl` (same as the 0.9.0 approach)
+3. **`SSL_has_pending`** — not available in LibreSSL; only `SSL_pending` exists
+4. **`SSL_get_peer_certificate`** — LibreSSL uses the pre-3.0.x name (not `SSL_get1_peer_certificate`)
+5. **`OPENSSL_INIT_new`/`OPENSSL_INIT_free`** — not available in LibreSSL. Init uses `OPENSSL_init_ssl` directly with no settings object
 
 ## ifdef Conventions
 
@@ -27,7 +37,7 @@ Version-specific code uses two patterns:
 
 **FFI declarations** use `if` guards on the `use` statement:
 ```pony
-use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x"
+use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
 use @SSLv23_method[Pointer[None]]() if "openssl_0.9.0"
 ```
 
@@ -54,7 +64,7 @@ Every ifdef chain must end with `compile_error` to catch missing defines at comp
 | `ssl/net/x509.pony` | Certificate name extraction and hostname matching |
 | `ssl/crypto/digest.pony` | Hash digests (MD5, SHA family, SHAKE) via EVP API |
 | `ssl/crypto/hmac_sha256.pony` | HMAC-SHA-256 message authentication (RFC 2104) |
-| `ssl/crypto/pbkdf2_sha256.pony` | PBKDF2 key derivation with HMAC-SHA-256 (RFC 2898, OpenSSL 1.1.x+ only) |
+| `ssl/crypto/pbkdf2_sha256.pony` | PBKDF2 key derivation with HMAC-SHA-256 (RFC 2898, OpenSSL 1.1.x+/LibreSSL) |
 | `ssl/crypto/rand_bytes.pony` | Cryptographically secure random byte generation |
 
 ## Known Issues

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
 	  SSL = -Dopenssl_1.1.x
   else ifeq ($(ssl), 0.9.0)
 	  SSL = -Dopenssl_0.9.0
+  else ifeq ($(ssl), libressl)
+	  SSL = -Dlibressl
   else
     $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
   endif

--- a/make.ps1
+++ b/make.ps1
@@ -67,7 +67,7 @@ if (($Version -eq "") -and (Test-Path -Path "$rootDir\VERSION"))
   $Version = (Get-Content "$rootDir\VERSION") + "-" + (& git 'rev-parse' '--short' '--verify' 'HEAD^')
 }
 
-$ponyArgs = "--define openssl_0.9.0 --path $rootDir"
+$ponyArgs = "--define libressl --path $rootDir"
 
 Write-Host "Configuration:    $Config"
 Write-Host "Version:          $Version"

--- a/ssl/crypto/_test.pony
+++ b/ssl/crypto/_test.pony
@@ -23,7 +23,7 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[USize](_TestHmacSha256Deterministic))
     test(Property1UnitTest[USize](_TestRandBytesOutputLength))
     test(Property1UnitTest[USize](_TestRandBytesNonConstant))
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       test(_TestPbkdf2Sha256Rfc7914)
       test(_TestPbkdf2Sha256Scram)
       test(Property1UnitTest[USize](_TestPbkdf2Sha256OutputLength))
@@ -311,7 +311,7 @@ class \nodoc\ iso _TestPbkdf2Sha256Rfc7914 is UnitTest
   fun name(): String => "crypto/Pbkdf2Sha256/RFC7914"
 
   fun apply(h: TestHelper) ? =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       // Test Vector 1: Password "passwd", Salt "salt", c=1, dkLen=64
       h.assert_eq[String](
         "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc" +
@@ -334,7 +334,7 @@ class \nodoc\ iso _TestPbkdf2Sha256Scram is UnitTest
   fun name(): String => "crypto/Pbkdf2Sha256/SCRAM"
 
   fun apply(h: TestHelper) ? =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       // Salt: decoded bytes of base64 "W22ZaJ0SNY7soEsUEjb6gQ=="
       let salt = recover val [as U8:
         0x5b; 0x6d; 0x99; 0x68; 0x9d; 0x12; 0x35; 0x8e
@@ -393,7 +393,7 @@ class \nodoc\ iso _TestPbkdf2Sha256OutputLength is Property1[USize]
     Generators.usize(1, 128)
 
   fun ref property(sample: USize, h: PropertyHelper) ? =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       h.assert_eq[USize](sample,
         Pbkdf2Sha256("p", "s", 1, sample)?.size())
     end
@@ -405,7 +405,7 @@ class \nodoc\ iso _TestPbkdf2Sha256Deterministic is Property1[USize]
     Generators.usize(1, 64)
 
   fun ref property(sample: USize, h: PropertyHelper) ? =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       h.assert_array_eq[U8](
         Pbkdf2Sha256("p", "s", 1, sample)?,
         Pbkdf2Sha256("p", "s", 1, sample)?)

--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -3,13 +3,13 @@ use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:crypto"
 use "lib:bcrypt" if windows
 
-use @EVP_MD_CTX_new[Pointer[_EVPCTX]]() if "openssl_1.1.x" or "openssl_3.0.x"
+use @EVP_MD_CTX_new[Pointer[_EVPCTX]]() if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
 use @EVP_MD_CTX_create[Pointer[_EVPCTX]]() if not "openssl_1.1.x" or "openssl_3.0.x"
 use @EVP_DigestInit_ex[I32](ctx: Pointer[_EVPCTX] tag, t: Pointer[_EVPMD], impl: USize)
 use @EVP_DigestUpdate[I32](ctx: Pointer[_EVPCTX] tag, d: Pointer[U8] tag, cnt: USize)
 use @EVP_DigestFinal_ex[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, s: Pointer[USize])
 use @EVP_DigestFinalXOF[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, len: USize) if "openssl_3.0.x"
-use @EVP_MD_CTX_free[None](ctx: Pointer[_EVPCTX]) if "openssl_1.1.x" or "openssl_3.0.x"
+use @EVP_MD_CTX_free[None](ctx: Pointer[_EVPCTX]) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
 use @EVP_MD_CTX_destroy[None](ctx: Pointer[_EVPCTX]) if not "openssl_1.1.x" or "openssl_3.0.x"
 
 use @EVP_md5[Pointer[_EVPMD]]()
@@ -41,7 +41,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 16
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       _ctx = @EVP_MD_CTX_create()
@@ -54,7 +54,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 20
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       _ctx = @EVP_MD_CTX_create()
@@ -67,7 +67,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 20
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       _ctx = @EVP_MD_CTX_create()
@@ -80,7 +80,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 28
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       _ctx = @EVP_MD_CTX_create()
@@ -93,7 +93,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 32
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       _ctx = @EVP_MD_CTX_create()
@@ -106,7 +106,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 48
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       _ctx = @EVP_MD_CTX_create()
@@ -119,7 +119,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 64
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       _ctx = @EVP_MD_CTX_create()
@@ -140,7 +140,7 @@ class Digest
       _ctx = @EVP_MD_CTX_new()
       @EVP_DigestInit_ex(_ctx, @EVP_shake128(), USize(0))
     else
-      compile_error "openssl_0.9.x dose not support shake128"
+      compile_error "shake128 is only supported with OpenSSL 1.1.x or 3.0.x"
     end
 
   new shake256() =>
@@ -157,7 +157,7 @@ class Digest
       _ctx = @EVP_MD_CTX_new()
       @EVP_DigestInit_ex(_ctx, @EVP_shake256(), USize(0))
     else
-      compile_error "openssl_0.9.x dose not support shake256"
+      compile_error "shake256 is only supported with OpenSSL 1.1.x or 3.0.x"
     end
 
   fun ref append(input: ByteSeq) ? =>
@@ -189,7 +189,7 @@ class Digest
           @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[USize])
         end
       end
-      ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+      ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
         @EVP_MD_CTX_free(_ctx)
       else
         @EVP_MD_CTX_destroy(_ctx)

--- a/ssl/crypto/pbkdf2_sha256.pony
+++ b/ssl/crypto/pbkdf2_sha256.pony
@@ -6,7 +6,7 @@ use @PKCS5_PBKDF2_HMAC[I32](
   pass: Pointer[U8] tag, passlen: I32,
   salt: Pointer[U8] tag, saltlen: I32, iter: I32,
   digest: Pointer[_EVPMD],
-  keylen: I32, out: Pointer[U8] tag) if "openssl_1.1.x" or "openssl_3.0.x"
+  keylen: I32, out: Pointer[U8] tag) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
 
 primitive Pbkdf2Sha256
   """
@@ -16,7 +16,7 @@ primitive Pbkdf2Sha256
   Returns a key of the requested length, or raises an error if the derivation
   fails (e.g., zero iterations).
 
-  Requires OpenSSL 1.1.x or 3.0.x. Not available on the legacy 0.9.0 path.
+  Supported on OpenSSL 1.1.x, OpenSSL 3.0.x, and LibreSSL.
 
   ```pony
   let key = Pbkdf2Sha256("password", "salt", 4096, 32)?
@@ -25,7 +25,7 @@ primitive Pbkdf2Sha256
   fun tag apply(password: ByteSeq, salt: ByteSeq, iterations: U32,
     key_length: USize): Array[U8] val ?
   =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       recover
         let arr = Array[U8].init(0, key_length)
         let rc = @PKCS5_PBKDF2_HMAC(

--- a/ssl/net/_ssl_init.pony
+++ b/ssl/net/_ssl_init.pony
@@ -31,6 +31,8 @@ primitive _SSLInit
         _OpenSslInitLoadSslStrings() + _OpenSslInitLoadCryptoStrings(),
         settings)
       @OPENSSL_INIT_free(settings)
+    elseif "libressl" then
+      @OPENSSL_init_ssl(0, Pointer[_OpenSslInitSettings])
     elseif "openssl_0.9.0" then
       @SSL_load_error_strings()
       @SSL_library_init()

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -15,7 +15,7 @@ use @SSL_set_accept_state[None](ssl: Pointer[_SSL])
 use @SSL_set_connect_state[None](ssl: Pointer[_SSL])
 use @SSL_do_handshake[I32](ssl: Pointer[_SSL])
 use @SSL_get0_alpn_selected[None](ssl: Pointer[_SSL] tag, data: Pointer[Pointer[U8] iso],
-  len: Pointer[U32]) if "openssl_1.1.x" or "openssl_3.0.x"
+  len: Pointer[U32]) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
 use @SSL_pending[I32](ssl: Pointer[_SSL])
 use @SSL_read[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: U32)
 use @SSL_write[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: U32)
@@ -24,7 +24,7 @@ use @BIO_write[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
 use @SSL_get_error[I32](ssl: Pointer[_SSL], ret: I32)
 use @BIO_ctrl_pending[USize](bio: Pointer[_BIO] tag)
 use @SSL_has_pending[I32](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x"
-use @SSL_get_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_0.9.0"
+use @SSL_get_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_0.9.0" or "libressl"
 use @SSL_get1_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_3.0.x"
 
 primitive _SSL
@@ -100,7 +100,7 @@ class SSL
     """
     var ptr: Pointer[U8] iso = recover Pointer[U8] end
     var len = U32(0)
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       @SSL_get0_alpn_selected(_ssl, addressof ptr, addressof len)
     end
 
@@ -264,7 +264,7 @@ class SSL
     if _verify and (_hostname.size() > 0) then
       let cert = ifdef "openssl_3.0.x" then
         @SSL_get1_peer_certificate(_ssl)
-      elseif "openssl_1.1.x" or "openssl_0.9.0" then
+      elseif "openssl_1.1.x" or "openssl_0.9.0" or "libressl" then
         @SSL_get_peer_certificate(_ssl)
       else
         compile_error "You must select an SSL version to use."

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -11,7 +11,7 @@ use @SSL_CTX_ctrl[ILong](
   arg: ULong,
   parg: Pointer[None])
 use @SSLv23_method[Pointer[None]]() if "openssl_0.9.0"
-use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x"
+use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
 use @SSL_CTX_new[Pointer[_SSLContext]](method: Pointer[None])
 use @SSL_CTX_free[None](ctx: Pointer[_SSLContext] tag)
 use @SSL_CTX_clear_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x"
@@ -36,9 +36,9 @@ use @CertCloseStore[Bool](store: Pointer[U8] tag, flags: U32) if windows
 use @SSL_CTX_set_cipher_list[I32](ctx: Pointer[_SSLContext] tag, control: Pointer[U8] tag)
 use @SSL_CTX_set_verify_depth[None](ctx: Pointer[_SSLContext] tag, depth: U32)
 use @SSL_CTX_set_alpn_select_cb[None](ctx: Pointer[_SSLContext] tag, cb: _ALPNSelectCallback,
-   resolver: ALPNProtocolResolver) if "openssl_1.1.x" or "openssl_3.0.x"
+   resolver: ALPNProtocolResolver) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
 use @SSL_CTX_set_alpn_protos[I32](ctx: Pointer[_SSLContext] tag, protos: Pointer[U8] tag,
-  protos_len: USize) if "openssl_1.1.x" or "openssl_3.0.x"
+  protos_len: USize) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
 
 primitive _SSLContext
 
@@ -83,7 +83,7 @@ class val SSLContext
     """
     Create an SSL context.
     """
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @SSL_CTX_new(@TLS_method())
 
       // Allow only newer ciphers.
@@ -106,7 +106,7 @@ class val SSLContext
   fun _set_options(opts: ULong) =>
     ifdef "openssl_1.1.x" or "openssl_3.0.x" then
       @SSL_CTX_set_options(_ctx, opts)
-    elseif "openssl_0.9.0" then
+    elseif "openssl_0.9.0" or "libressl" then
       @SSL_CTX_ctrl(_ctx, _SslCtrlSetOptions(), opts, Pointer[None])
     else
       compile_error "You must select an SSL version to use."
@@ -115,7 +115,7 @@ class val SSLContext
   fun _clear_options(opts: ULong) =>
     ifdef "openssl_1.1.x" or "openssl_3.0.x" then
       @SSL_CTX_clear_options(_ctx, opts)
-    elseif "openssl_0.9.0" then
+    elseif "openssl_0.9.0" or "libressl" then
       @SSL_CTX_ctrl(_ctx, _SslCtrlClearOptions(), opts, Pointer[None])
     else
       compile_error "You must select an SSL version to use."
@@ -315,10 +315,10 @@ class val SSLContext
     """
     Use `resolver` to choose the protocol to be selected for incomming connections.
 
-    Returns true on success
-    Requires OpenSSL >= 1.0.2
+    Returns true on success.
+    Supported on OpenSSL 1.1.x, OpenSSL 3.0.x, and LibreSSL.
     """
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       @SSL_CTX_set_alpn_select_cb(
         _ctx, addressof SSLContext._alpn_select_cb, resolver)
       return true
@@ -333,10 +333,10 @@ class val SSLContext
     Configures the SSLContext to advertise the protocol names defined in `protocols` when connecting to a server
     protocol names must have a size of 1 to 255
 
-    Returns true on success
-    Requires OpenSSL >= 1.0.2
+    Returns true on success.
+    Supported on OpenSSL 1.1.x, OpenSSL 3.0.x, and LibreSSL.
     """
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       try
         let proto_list = _ALPNProtocolList.from_array(protocols)?
         let result =

--- a/ssl/net/x509.pony
+++ b/ssl/net/x509.pony
@@ -10,7 +10,7 @@ use @X509_get_ext_d2i[Pointer[_GeneralNameStack]](cert: Pointer[X509],
 use @OPENSSL_sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x"
 use @sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
-  if "openssl_0.9.0"
+  if "openssl_0.9.0" or "libressl"
 use @GENERAL_NAME_get0_value[Pointer[U8] tag](name: Pointer[_GeneralName],
   ptype: Pointer[I32])
 use @ASN1_STRING_type[I32](value: Pointer[U8] tag)
@@ -20,7 +20,7 @@ use @GENERAL_NAME_free[None](name: Pointer[_GeneralName])
 use @OPENSSL_sk_free[None](stack: Pointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x"
 use @sk_free[None](stack: Pointer[_GeneralNameStack])
-  if "openssl_0.9.0"
+  if "openssl_0.9.0" or "libressl"
 
 primitive _X509Name
 primitive _GeneralName
@@ -86,7 +86,7 @@ primitive X509
     var name =
       ifdef "openssl_1.1.x" or "openssl_3.0.x" then
         @OPENSSL_sk_pop(stack)
-      elseif "openssl_0.9.0" then
+      elseif "openssl_0.9.0" or "libressl" then
         @sk_pop(stack)
       else
         compile_error "You must select an SSL version to use."
@@ -132,7 +132,7 @@ primitive X509
       @GENERAL_NAME_free(name)
       ifdef "openssl_1.1.x" or "openssl_3.0.x" then
         name = @OPENSSL_sk_pop(stack)
-      elseif "openssl_0.9.0" then
+      elseif "openssl_0.9.0" or "libressl" then
         name = @sk_pop(stack)
       else
         compile_error "You must select an SSL version to use."
@@ -141,7 +141,7 @@ primitive X509
 
     ifdef "openssl_1.1.x" or "openssl_3.0.x" then
       @OPENSSL_sk_free(stack)
-    elseif "openssl_0.9.0" then
+    elseif "openssl_0.9.0" or "libressl" then
       @sk_free(stack)
     else
       compile_error "You must select an SSL version to use."


### PR DESCRIPTION
LibreSSL users previously built with `-Dopenssl_0.9.0`, which forced LibreSSL through a code path designed for ancient OpenSSL. This silently disabled ALPN, PBKDF2, and modern EVP/init APIs that LibreSSL supports.

The new `-Dlibressl` define gives LibreSSL its own code paths, based on the OpenSSL 1.1.x path with targeted overrides for five divergence points:
- `sk_pop`/`sk_free` naming (no `OPENSSL_` prefix)
- `SSL_CTX_set_options`/`SSL_CTX_clear_options` are macros, not functions (uses `SSL_CTX_ctrl`)
- `SSL_has_pending` is not available
- `SSL_get_peer_certificate` (not `SSL_get1_peer_certificate`)
- `OPENSSL_INIT_new`/`OPENSSL_INIT_free` don't exist (init calls `OPENSSL_init_ssl` directly)

This is PR 1 of 2 for #9. PR 2 will remove the `-Dopenssl_0.9.0` path entirely.

Follow-up: #17 tracks verifying SHAKE128/256 support on LibreSSL.