### PR TITLE
Remove OpenSSL 0.9.0 support

### DIFF
--- a/.release-notes/remove-openssl-0.9.0.md
+++ b/.release-notes/remove-openssl-0.9.0.md
@@ -1,0 +1,7 @@
+## Remove OpenSSL 0.9.0 support
+
+Support for `-Dopenssl_0.9.0` has been removed. OpenSSL 0.9.8 reached end-of-life in January 2016 and has 64 known CVEs. It should not be used.
+
+LibreSSL users who were previously building with `-Dopenssl_0.9.0` should switch to `-Dlibressl`.
+
+If you are using OpenSSL, switch to `-Dopenssl_1.1.x` or `-Dopenssl_3.0.x` depending on your installed version.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,6 @@ SSL version is **required**. Valid values:
 |---|---|---|
 | `3.0.x` | `-Dopenssl_3.0.x` | OpenSSL 3.x |
 | `1.1.x` | `-Dopenssl_1.1.x` | OpenSSL 1.1.x |
-| `0.9.0` | `-Dopenssl_0.9.0` | Legacy (pending removal via #9 PR 2) |
 | `libressl` | `-Dlibressl` | LibreSSL |
 
 Windows (`make.ps1`) always builds against LibreSSL. The define is hardcoded on line 70.
@@ -26,7 +25,7 @@ Windows (`make.ps1`) always builds against LibreSSL. The define is hardcoded on 
 LibreSSL's API is mostly OpenSSL 1.1.x compatible, with five differences that require separate code paths:
 
 1. **`sk_pop`/`sk_free`** — LibreSSL uses old names (no `OPENSSL_` prefix)
-2. **`SSL_CTX_set_options`/`SSL_CTX_clear_options`** — macros in LibreSSL, not real functions. Pony FFI can't call macros, so LibreSSL uses `SSL_CTX_ctrl` (same as the 0.9.0 approach)
+2. **`SSL_CTX_set_options`/`SSL_CTX_clear_options`** — macros in LibreSSL, not real functions. Pony FFI can't call macros, so LibreSSL uses `SSL_CTX_ctrl`
 3. **`SSL_has_pending`** — not available in LibreSSL; only `SSL_pending` exists
 4. **`SSL_get_peer_certificate`** — LibreSSL uses the pre-3.0.x name (not `SSL_get1_peer_certificate`)
 5. **`OPENSSL_INIT_new`/`OPENSSL_INIT_free`** — not available in LibreSSL. Init uses `OPENSSL_init_ssl` directly with no settings object
@@ -38,15 +37,14 @@ Version-specific code uses two patterns:
 **FFI declarations** use `if` guards on the `use` statement:
 ```pony
 use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
-use @SSLv23_method[Pointer[None]]() if "openssl_0.9.0"
 ```
 
 **Code blocks** use `ifdef` with `elseif` chains and a compile_error catch-all:
 ```pony
 ifdef "openssl_1.1.x" or "openssl_3.0.x" then
-  // modern path
-elseif "openssl_0.9.0" then
-  // legacy path
+  // OpenSSL path
+elseif "libressl" then
+  // LibreSSL path (when it diverges from OpenSSL)
 else
   compile_error "You must select an SSL version to use."
 end
@@ -66,7 +64,3 @@ Every ifdef chain must end with `compile_error` to catch missing defines at comp
 | `ssl/crypto/hmac_sha256.pony` | HMAC-SHA-256 message authentication (RFC 2104) |
 | `ssl/crypto/pbkdf2_sha256.pony` | PBKDF2 key derivation with HMAC-SHA-256 (RFC 2898, OpenSSL 1.1.x+/LibreSSL) |
 | `ssl/crypto/rand_bytes.pony` | Cryptographically secure random byte generation |
-
-## Known Issues
-
-- `digest.pony` lines 7 and 13 have an operator precedence bug: `if not "openssl_1.1.x" or "openssl_3.0.x"` parses as `(not "openssl_1.1.x") or "openssl_3.0.x"` rather than the intended `not ("openssl_1.1.x" or "openssl_3.0.x")`. Harmless in practice since the declarations are unused when the wrong version is active. Will be resolved when the 0.9.0 path is removed (#9 PR 2).

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
 	  SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
 	  SSL = -Dopenssl_1.1.x
-  else ifeq ($(ssl), 0.9.0)
-	  SSL = -Dopenssl_0.9.0
   else ifeq ($(ssl), libressl)
 	  SSL = -Dlibressl
   else

--- a/README.md
+++ b/README.md
@@ -17,15 +17,7 @@ Production ready.
 
 ## Supported SSL versions
 
-The 0.9.0, 1.1.x, and 3.0.x OpenSSL versions and corresponding compatible LibreSSL library versions are supported.
-
-The default is to use the 0.9.x library APIs. You can change the selected supported library version at compile-time by using Pony's compile time definition functionality.
-
-### Using OpenSSL 0.9.0
-
-```bash
-corral run -- ponyc -Dopenssl_0.9.0
-```
+OpenSSL 1.1.x, OpenSSL 3.0.x, and LibreSSL are supported. Select the library version at compile-time using Pony's compile time definition functionality.
 
 ### Using OpenSSL 1.1.x
 
@@ -37,6 +29,12 @@ corral run -- ponyc -Dopenssl_1.1.x
 
 ```bash
 corral run -- ponyc -Dopenssl_3.0.x
+```
+
+### Using LibreSSL
+
+```bash
+corral run -- ponyc -Dlibressl
 ```
 
 ## Dependencies
@@ -97,7 +95,7 @@ sudo zypper install libopenssl-devel
 
 If you use [Corral](https://github.com/ponylang/corral) to include this package as dependency of a project, Corral will download and build LibreSSL for you the first time you run `corral fetch`.  Otherwise, before using this package, you must run `.\make.ps1 libs` in its base directory to download and build LibreSSL for Windows. In both cases, you will need CMake (3.15 or higher) and 7Zip (`7z.exe`) in your `PATH`; and Visual Studio 2017 or later (or the Visual C++ Build Tools 2017 or later) installed in your system.
 
-You should pass `--define openssl_0.9.0` to Ponyc when using this package on Windows.
+You should pass `--define libressl` to Ponyc when using this package on Windows.
 
 ## API Documentation
 

--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -4,13 +4,11 @@ use "lib:crypto"
 use "lib:bcrypt" if windows
 
 use @EVP_MD_CTX_new[Pointer[_EVPCTX]]() if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
-use @EVP_MD_CTX_create[Pointer[_EVPCTX]]() if not "openssl_1.1.x" or "openssl_3.0.x"
 use @EVP_DigestInit_ex[I32](ctx: Pointer[_EVPCTX] tag, t: Pointer[_EVPMD], impl: USize)
 use @EVP_DigestUpdate[I32](ctx: Pointer[_EVPCTX] tag, d: Pointer[U8] tag, cnt: USize)
 use @EVP_DigestFinal_ex[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, s: Pointer[USize])
 use @EVP_DigestFinalXOF[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, len: USize) if "openssl_3.0.x"
 use @EVP_MD_CTX_free[None](ctx: Pointer[_EVPCTX]) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
-use @EVP_MD_CTX_destroy[None](ctx: Pointer[_EVPCTX]) if not "openssl_1.1.x" or "openssl_3.0.x"
 
 use @EVP_md5[Pointer[_EVPMD]]()
 use @EVP_ripemd160[Pointer[_EVPMD]]()
@@ -44,7 +42,7 @@ class Digest
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
-      _ctx = @EVP_MD_CTX_create()
+      compile_error "You must select an SSL version to use."
     end
     @EVP_DigestInit_ex(_ctx, @EVP_md5(), USize(0))
 
@@ -57,7 +55,7 @@ class Digest
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
-      _ctx = @EVP_MD_CTX_create()
+      compile_error "You must select an SSL version to use."
     end
     @EVP_DigestInit_ex(_ctx, @EVP_ripemd160(), USize(0))
 
@@ -70,7 +68,7 @@ class Digest
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
-      _ctx = @EVP_MD_CTX_create()
+      compile_error "You must select an SSL version to use."
     end
     @EVP_DigestInit_ex(_ctx, @EVP_sha1(), USize(0))
 
@@ -83,7 +81,7 @@ class Digest
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
-      _ctx = @EVP_MD_CTX_create()
+      compile_error "You must select an SSL version to use."
     end
     @EVP_DigestInit_ex(_ctx, @EVP_sha224(), USize(0))
 
@@ -96,7 +94,7 @@ class Digest
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
-      _ctx = @EVP_MD_CTX_create()
+      compile_error "You must select an SSL version to use."
     end
     @EVP_DigestInit_ex(_ctx, @EVP_sha256(), USize(0))
 
@@ -109,7 +107,7 @@ class Digest
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
-      _ctx = @EVP_MD_CTX_create()
+      compile_error "You must select an SSL version to use."
     end
     @EVP_DigestInit_ex(_ctx, @EVP_sha384(), USize(0))
 
@@ -122,7 +120,7 @@ class Digest
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
-      _ctx = @EVP_MD_CTX_create()
+      compile_error "You must select an SSL version to use."
     end
     @EVP_DigestInit_ex(_ctx, @EVP_sha512(), USize(0))
 
@@ -192,7 +190,7 @@ class Digest
       ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
         @EVP_MD_CTX_free(_ctx)
       else
-        @EVP_MD_CTX_destroy(_ctx)
+        compile_error "You must select an SSL version to use."
       end
       let h = (consume digest).array()
       _hash = h

--- a/ssl/crypto/pbkdf2_sha256.pony
+++ b/ssl/crypto/pbkdf2_sha256.pony
@@ -38,8 +38,6 @@ primitive Pbkdf2Sha256
         if rc != 1 then error end
         arr
       end
-    elseif "openssl_0.9.0" then
-      compile_error "Pbkdf2Sha256 requires OpenSSL 1.1.x or 3.0.x"
     else
       compile_error "You must select an SSL version to use."
     end

--- a/ssl/net/_ssl_init.pony
+++ b/ssl/net/_ssl_init.pony
@@ -3,14 +3,9 @@ use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:ssl"
 use "lib:crypto"
 
-use @ponyint_ssl_multithreading[Pointer[U8]](count: U32)
 use @OPENSSL_init_ssl[I32](opts: U64, settings: Pointer[_OpenSslInitSettings])
 use @OPENSSL_INIT_new[Pointer[_OpenSslInitSettings]]()
 use @OPENSSL_INIT_free[None](settings: Pointer[_OpenSslInitSettings])
-use @SSL_library_init[I32]() if "openssl_0.9.0"
-use @SSL_load_error_strings[None]() if "openssl_0.9.0"
-use @CRYPTO_num_locks[I32]() if "openssl_0.9.0"
-use @CRYPTO_set_locking_callback[None](cb: Pointer[U8]) if "openssl_0.9.0"
 
 primitive _OpenSslInitSettings
 
@@ -33,12 +28,6 @@ primitive _SSLInit
       @OPENSSL_INIT_free(settings)
     elseif "libressl" then
       @OPENSSL_init_ssl(0, Pointer[_OpenSslInitSettings])
-    elseif "openssl_0.9.0" then
-      @SSL_load_error_strings()
-      @SSL_library_init()
-      let cb =
-        @ponyint_ssl_multithreading(@CRYPTO_num_locks().u32())
-      @CRYPTO_set_locking_callback(cb)
     else
       compile_error "You must select an SSL version to use."
     end

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -24,7 +24,7 @@ use @BIO_write[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
 use @SSL_get_error[I32](ssl: Pointer[_SSL], ret: I32)
 use @BIO_ctrl_pending[USize](bio: Pointer[_BIO] tag)
 use @SSL_has_pending[I32](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x"
-use @SSL_get_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_0.9.0" or "libressl"
+use @SSL_get_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "libressl"
 use @SSL_get1_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_3.0.x"
 
 primitive _SSL
@@ -264,7 +264,7 @@ class SSL
     if _verify and (_hostname.size() > 0) then
       let cert = ifdef "openssl_3.0.x" then
         @SSL_get1_peer_certificate(_ssl)
-      elseif "openssl_1.1.x" or "openssl_0.9.0" or "libressl" then
+      elseif "openssl_1.1.x" or "libressl" then
         @SSL_get_peer_certificate(_ssl)
       else
         compile_error "You must select an SSL version to use."

--- a/ssl/net/x509.pony
+++ b/ssl/net/x509.pony
@@ -10,7 +10,7 @@ use @X509_get_ext_d2i[Pointer[_GeneralNameStack]](cert: Pointer[X509],
 use @OPENSSL_sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x"
 use @sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
-  if "openssl_0.9.0" or "libressl"
+  if "libressl"
 use @GENERAL_NAME_get0_value[Pointer[U8] tag](name: Pointer[_GeneralName],
   ptype: Pointer[I32])
 use @ASN1_STRING_type[I32](value: Pointer[U8] tag)
@@ -20,7 +20,7 @@ use @GENERAL_NAME_free[None](name: Pointer[_GeneralName])
 use @OPENSSL_sk_free[None](stack: Pointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x"
 use @sk_free[None](stack: Pointer[_GeneralNameStack])
-  if "openssl_0.9.0" or "libressl"
+  if "libressl"
 
 primitive _X509Name
 primitive _GeneralName
@@ -86,7 +86,7 @@ primitive X509
     var name =
       ifdef "openssl_1.1.x" or "openssl_3.0.x" then
         @OPENSSL_sk_pop(stack)
-      elseif "openssl_0.9.0" or "libressl" then
+      elseif "libressl" then
         @sk_pop(stack)
       else
         compile_error "You must select an SSL version to use."
@@ -132,7 +132,7 @@ primitive X509
       @GENERAL_NAME_free(name)
       ifdef "openssl_1.1.x" or "openssl_3.0.x" then
         name = @OPENSSL_sk_pop(stack)
-      elseif "openssl_0.9.0" or "libressl" then
+      elseif "libressl" then
         name = @sk_pop(stack)
       else
         compile_error "You must select an SSL version to use."
@@ -141,7 +141,7 @@ primitive X509
 
     ifdef "openssl_1.1.x" or "openssl_3.0.x" then
       @OPENSSL_sk_free(stack)
-    elseif "openssl_0.9.0" or "libressl" then
+    elseif "libressl" then
       @sk_free(stack)
     else
       compile_error "You must select an SSL version to use."


### PR DESCRIPTION
OpenSSL 0.9.8 reached end-of-life in January 2016 and has 64 known CVEs. The `-Dopenssl_0.9.0` code path used legacy APIs (`SSL_library_init`, `EVP_MD_CTX_create`/`destroy`, `SSLv23_method`) that made the codebase harder to maintain.

LibreSSL users who were building with `-Dopenssl_0.9.0` should use `-Dlibressl` instead (added in #18). OpenSSL users should use `-Dopenssl_1.1.x` or `-Dopenssl_3.0.x`.

Also removes dead code (`_SslOpNoSslV2`, `_SslOpNoSslV3`, `_SslOpNoSslMask`) that was only referenced from the 0.9.0 init path, and resolves the operator precedence bug in `digest.pony` (documented in CLAUDE.md Known Issues) by removing the affected declarations entirely.

Closes #9