### PR TITLE
SSLConnection ignores _notify.received value

### DIFF
--- a/.release-notes/ssl-connection-received-return.md
+++ b/.release-notes/ssl-connection-received-return.md
@@ -1,0 +1,5 @@
+## SSLConnection ignores _notify.received value
+
+Previously, when a `TCPConnectionNotify` wrapped by `SSLConnection` returned `false` from its `received` callback to request yielding to other actors, `SSLConnection` discarded the return value and always told `TCPConnection` to continue reading. This meant backpressure signaling through SSL connections had no effect.
+
+`SSLConnection` now properly propagates the wrapped notify's `received` return value to `TCPConnection`, allowing the backpressure/yield mechanism to work through SSL connections.


### PR DESCRIPTION
SSLConnection.received() always returned true to TCPConnection, discarding the wrapped notify's return value. This meant a notify returning false to request yielding had no effect through SSL connections.

_poll() now tracks the inner notify's return value and propagates it back through received(). The SSL send loop still executes after an early break from the read loop to ensure protocol data is flushed.

Closes #4