### PR TITLE
Add variable-length output support to SHAKE digests

### DIFF
--- a/.release-notes/shake-variable-length.md
+++ b/.release-notes/shake-variable-length.md
@@ -1,0 +1,12 @@
+## Add variable-length output support to SHAKE digests
+
+The `shake128` and `shake256` constructors on `Digest` now accept an optional `size` parameter that controls the output length in bytes. The defaults match the previous fixed sizes (16 bytes for SHAKE128, 32 for SHAKE256), so existing code is unaffected.
+
+Variable-length output requires OpenSSL 3.0.x. On OpenSSL 1.1.x, the default size is always used regardless of the parameter value.
+
+```pony
+// 64-byte SHAKE256 digest (OpenSSL 3.0.x)
+let d = Digest.shake256(64)
+d.append("input data")?
+let hash: Array[U8] val = d.final()  // 64 bytes
+```

--- a/examples/digest-example/digest-example.pony
+++ b/examples/digest-example/digest-example.pony
@@ -13,3 +13,16 @@ actor Main
     else
       env.out.print("Error computing hash")
     end
+
+    // SHAKE256 with variable-length output (OpenSSL 3.0.x only)
+    ifdef "openssl_3.0.x" then
+      let shake: Digest = Digest.shake256(64)
+      try
+        shake.append("Hello ")?
+        shake.append("World")?
+        let shake_hash: Array[U8] val = shake.final()
+        env.out.print("SHAKE256 (64 bytes): " + ToHexString(shake_hash))
+      else
+        env.out.print("Error computing SHAKE hash")
+      end
+    end

--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -124,16 +124,22 @@ class Digest
     end
     @EVP_DigestInit_ex(_ctx, @EVP_sha512(), USize(0))
 
-  new shake128() =>
+  new shake128(size': USize = 16) =>
     """
-    Use the Shake128 algorithm to calculate the hash.
+    Use the SHAKE128 algorithm to calculate the hash.
+
+    SHAKE128 is an extendable output function (XOF) that can produce
+    variable-length output. The `size'` parameter controls the output length
+    in bytes (default: 16). Variable-length output requires OpenSSL 3.0.x;
+    on OpenSSL 1.1.x, the default size is always used.
     """
-    _digest_size = 16
     ifdef "openssl_1.1.x" or "openssl_3.0.x" then
-      ifdef not "openssl_3.0.x" then
-        _variable_length = false
-      else
+      ifdef "openssl_3.0.x" then
         _variable_length = true
+        _digest_size = size'
+      else
+        _variable_length = false
+        _digest_size = 16
       end
       _ctx = @EVP_MD_CTX_new()
       @EVP_DigestInit_ex(_ctx, @EVP_shake128(), USize(0))
@@ -141,16 +147,22 @@ class Digest
       compile_error "shake128 is only supported with OpenSSL 1.1.x or 3.0.x"
     end
 
-  new shake256() =>
+  new shake256(size': USize = 32) =>
     """
-    Use the Shake256 algorithm to calculate the hash.
+    Use the SHAKE256 algorithm to calculate the hash.
+
+    SHAKE256 is an extendable output function (XOF) that can produce
+    variable-length output. The `size'` parameter controls the output length
+    in bytes (default: 32). Variable-length output requires OpenSSL 3.0.x;
+    on OpenSSL 1.1.x, the default size is always used.
     """
-    _digest_size = 32
     ifdef "openssl_1.1.x" or "openssl_3.0.x" then
-      ifdef not "openssl_3.0.x" then
-        _variable_length = false
-      else
+      ifdef "openssl_3.0.x" then
         _variable_length = true
+        _digest_size = size'
+      else
+        _variable_length = false
+        _digest_size = 32
       end
       _ctx = @EVP_MD_CTX_new()
       @EVP_DigestInit_ex(_ctx, @EVP_shake256(), USize(0))


### PR DESCRIPTION
SHAKE128 and SHAKE256 are XOFs that can produce arbitrary-length output, but the constructors hardcoded fixed sizes (16 and 32 bytes). The infrastructure for variable length already existed (`_variable_length` flag, `EVP_DigestFinalXOF` dispatch in `final()`) but was inaccessible.

Adds a `size` parameter to both constructors with defaults matching the previous fixed values, so existing code is unaffected. On OpenSSL 1.1.x, the parameter is accepted but ignored (the default is always used) to prevent buffer overflow from `EVP_DigestFinal_ex` writing a fixed-size output.

Four property tests (OpenSSL 3.0.x only) verify output length matches the requested size and that the XOF prefix property holds: a shorter output is a prefix of a longer output from the same input.

Closes #6