### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -338,7 +338,7 @@ class val SSLContext
     try
       let proto_arr = _ALPNProtocolList.to_array(proto_arr_str)?
 
-      match resolver.resolve(proto_arr)
+      match \exhaustive\ resolver.resolve(proto_arr)
       | let matched: String =>
       var size = matched.size()
       if (size > 0) and (size <= 255) then


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.