### PR TITLE
Add test-one Makefile target for running individual tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ test: unit-tests examples
 unit-tests: $(tests_binary)
 	$^ --exclude=integration --sequential
 
+test-one: $(tests_binary)
+	$^ --only="$(t)"
+
 $(tests_binary): $(GEN_FILES) $(SOURCE_FILES) | $(BUILD_DIR)
 	${GET_DEPENDENCIES_WITH}
 	${PONYC} ${SSL} -o ${BUILD_DIR} $(SRC_DIR)
@@ -69,4 +72,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all clean TAGS test
+.PHONY: all clean TAGS test test-one


### PR DESCRIPTION
Adds a `test-one` target that runs a single test by name using ponytest's `--only` flag:

```
make test-one t=TestName
```

Avoids full suite runs when iterating on a specific test during development or debugging.