### PR TITLE
Fix X509 hostname verification accepting empty certificate names

### DIFF
--- a/.release-notes/fix-match-name-empty-string.md
+++ b/.release-notes/fix-match-name-empty-string.md
@@ -1,0 +1,3 @@
+## Fix X509 hostname verification accepting empty certificate names
+
+`X509.valid_for_host` could incorrectly report that a certificate was valid for any hostname when the certificate's name list contained an empty string. An empty name now correctly fails to match any hostname.

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -23,6 +23,12 @@ actor \nodoc\ Main is TestList
       test(_TestTCPSSLThrottle)
     end
     test(Property1UnitTest[Array[String]](_TestALPNProtocolListRoundTrip))
+    test(_TestMatchNameEmptyName)
+    test(_TestMatchNameExactCaseInsensitive)
+    test(_TestMatchNameNoMatch)
+    test(_TestMatchNameIPLiteral)
+    test(_TestMatchNameWildcard)
+    test(_TestMatchNameWildcardInsufficientLevels)
 
 class \nodoc\ iso _TestALPNProtocolListEncoding is UnitTest
   """
@@ -784,3 +790,54 @@ class \nodoc\ iso _TestALPNProtocolListRoundTrip is Property1[Array[String]]
       h.assert_true(sample(i)? == decoded(i)?)
       i = i + 1
     end
+
+class \nodoc\ iso _TestMatchNameEmptyName is UnitTest
+  fun name(): String => "net/ssl/X509._match_name/empty_name"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(X509._match_name("example.com", ""))
+    h.assert_false(X509._match_name("localhost", ""))
+    h.assert_false(X509._match_name("192.168.1.1", ""))
+
+class \nodoc\ iso _TestMatchNameExactCaseInsensitive is UnitTest
+  fun name(): String => "net/ssl/X509._match_name/exact_case_insensitive"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(X509._match_name("example.com", "example.com"))
+    h.assert_true(X509._match_name("Example.COM", "example.com"))
+    h.assert_true(X509._match_name("example.com", "EXAMPLE.COM"))
+
+class \nodoc\ iso _TestMatchNameNoMatch is UnitTest
+  fun name(): String => "net/ssl/X509._match_name/no_match"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(X509._match_name("example.com", "other.com"))
+    h.assert_false(X509._match_name("example.com", "example.org"))
+
+class \nodoc\ iso _TestMatchNameIPLiteral is UnitTest
+  fun name(): String => "net/ssl/X509._match_name/ip_literal"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(X509._match_name("192.168.1.1", "192.168.1.1"))
+    h.assert_false(X509._match_name("192.168.1.1", "192.168.1.2"))
+    // IP literals require exact match, not case-insensitive domain match
+    h.assert_false(X509._match_name("192.168.1.1", "*.168.1.1"))
+
+class \nodoc\ iso _TestMatchNameWildcard is UnitTest
+  fun name(): String => "net/ssl/X509._match_name/wildcard"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(X509._match_name("foo.example.com", "*.example.com"))
+    h.assert_true(X509._match_name("FOO.Example.COM", "*.example.com"))
+
+class \nodoc\ iso _TestMatchNameWildcardInsufficientLevels is UnitTest
+  fun name(): String =>
+    "net/ssl/X509._match_name/wildcard_insufficient_levels"
+
+  fun apply(h: TestHelper) =>
+    // Wildcard alone is not valid
+    h.assert_false(X509._match_name("example.com", "*"))
+    // Wildcard with only one domain level is not valid
+    h.assert_false(X509._match_name("example.com", "*."))
+    // Wildcard followed by dot-dot is not valid
+    h.assert_false(X509._match_name("foo.example.com", "*..com"))

--- a/ssl/net/x509.pony
+++ b/ssl/net/x509.pony
@@ -158,7 +158,9 @@ primitive X509
       return host == name
     end
 
-    if host.compare_sub(name, name.size(), 0, 0, true) is Equal then
+    if (name.size() > 0) and
+      (host.compare_sub(name, name.size(), 0, 0, true) is Equal)
+    then
       // If the names are the same ignoring case, they match.
       return true
     end


### PR DESCRIPTION
`_match_name` used `compare_sub` with `name.size()` as the comparison length. When `name` was an empty string, this compared 0 bytes and returned `Equal`, causing any hostname to match. Combined with ponylang/ponyc#5048 (which produces empty strings for IP SANs), this could cause hostname verification to incorrectly pass.

Guard the `compare_sub` call with a `name.size() > 0` check.

Closes #34