### PR TITLE
Add OpenSSL 4.0.x support

### DIFF
--- a/.github/workflows/breakage-against-linux-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-linux-ponyc-latest.yml
@@ -92,3 +92,24 @@ jobs:
           type: stream
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  test-openssl-4-vs-ponyc-latest:
+    name: OpenSSL 4.x with ponyc main
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-4.0.0:nightly
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Test
+        run: make test config=debug ssl=4.0.x
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,16 @@ jobs:
       - name: Test
         run: make test config=debug ssl=3.0.x
 
+  test-openssl-4-vs-ponyc-release:
+    name: OpenSSL 4.x with most recent ponyc release
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-openssl-4.0.0:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Test
+        run: make test config=debug ssl=4.0.x
+
   test-x86-64-windows-vs-ponyc-release:
     name: Windows x86-64 (LibreSSL) with most recent ponyc release
     runs-on: windows-2025

--- a/.release-notes/add-openssl-4.0.x-support.md
+++ b/.release-notes/add-openssl-4.0.x-support.md
@@ -1,0 +1,4 @@
+## Add OpenSSL 4.0.x support
+
+OpenSSL 4.0.x is now a supported backend. Select it at compile time with `-Dopenssl_4.0.x`, or pass `ssl=4.0.x` to `make` when building the library itself. The library's API is unchanged; existing code continues to work without modification.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ SSL version is **required**. Valid values:
 
 | `ssl=` value | Define passed to ponyc | Backend |
 |---|---|---|
+| `4.0.x` | `-Dopenssl_4.0.x` | OpenSSL 4.x |
 | `3.0.x` | `-Dopenssl_3.0.x` | OpenSSL 3.x |
 | `1.1.x` | `-Dopenssl_1.1.x` | OpenSSL 1.1.x |
 | `libressl` | `-Dlibressl` | LibreSSL |
@@ -37,12 +38,12 @@ Version-specific code uses two patterns:
 
 **FFI declarations** use `if` guards on the `use` statement:
 ```pony
-use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
+use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 ```
 
 **Code blocks** use `ifdef` with `elseif` chains and a compile_error catch-all:
 ```pony
-ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
   // OpenSSL path
 elseif "libressl" then
   // LibreSSL path (when it diverges from OpenSSL)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
-  ifeq ($(ssl), 3.0.x)
+  ifeq ($(ssl), 4.0.x)
+	  SSL = -Dopenssl_4.0.x
+  else ifeq ($(ssl), 3.0.x)
 	  SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
 	  SSL = -Dopenssl_1.1.x

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Production ready.
 
 ## Supported SSL versions
 
-OpenSSL 1.1.x, OpenSSL 3.0.x, and LibreSSL are supported. Select the library version at compile-time using Pony's compile time definition functionality.
+OpenSSL 1.1.x, OpenSSL 3.0.x, OpenSSL 4.0.x, and LibreSSL are supported. Select the library version at compile-time using Pony's compile time definition functionality.
 
 ### Using OpenSSL 1.1.x
 
@@ -29,6 +29,12 @@ corral run -- ponyc -Dopenssl_1.1.x
 
 ```bash
 corral run -- ponyc -Dopenssl_3.0.x
+```
+
+### Using OpenSSL 4.0.x
+
+```bash
+corral run -- ponyc -Dopenssl_4.0.x
 ```
 
 ### Using LibreSSL

--- a/examples/digest-example/digest-example.pony
+++ b/examples/digest-example/digest-example.pony
@@ -14,8 +14,8 @@ actor Main
       env.out.print("Error computing hash")
     end
 
-    // SHAKE256 with variable-length output (OpenSSL 3.0.x only)
-    ifdef "openssl_3.0.x" then
+    // SHAKE256 with variable-length output (OpenSSL 3.0.x or 4.0.x)
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       let shake: Digest = Digest.shake256(64)
       try
         shake.append("Hello ")?

--- a/ssl/crypto/_test.pony
+++ b/ssl/crypto/_test.pony
@@ -23,13 +23,13 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[USize](_TestHmacSha256Deterministic))
     test(Property1UnitTest[USize](_TestRandBytesOutputLength))
     test(Property1UnitTest[USize](_TestRandBytesNonConstant))
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       test(_TestPbkdf2Sha256Rfc7914)
       test(_TestPbkdf2Sha256Scram)
       test(Property1UnitTest[USize](_TestPbkdf2Sha256OutputLength))
       test(Property1UnitTest[USize](_TestPbkdf2Sha256Deterministic))
     end
-    ifdef "openssl_3.0.x" then
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       test(Property1UnitTest[USize](_TestShake128OutputLength))
       test(Property1UnitTest[USize](_TestShake256OutputLength))
       test(Property1UnitTest[USize](_TestShake128XofPrefix))
@@ -179,7 +179,7 @@ class \nodoc\ iso _TestDigest is UnitTest
       "cd945c6a77006272322f911c9be31fa970043daa4b61cee607566cbfa2c69b09",
       ToHexString(sha512.final()))
 
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
       let shake128 = Digest.shake128()
       shake128.append("message1")?
       shake128.append("message2")?
@@ -326,7 +326,7 @@ class \nodoc\ iso _TestPbkdf2Sha256Rfc7914 is UnitTest
   fun name(): String => "crypto/Pbkdf2Sha256/RFC7914"
 
   fun apply(h: TestHelper) ? =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       // Test Vector 1: Password "passwd", Salt "salt", c=1, dkLen=64
       h.assert_eq[String](
         "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc" +
@@ -349,7 +349,7 @@ class \nodoc\ iso _TestPbkdf2Sha256Scram is UnitTest
   fun name(): String => "crypto/Pbkdf2Sha256/SCRAM"
 
   fun apply(h: TestHelper) ? =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       // Salt: decoded bytes of base64 "W22ZaJ0SNY7soEsUEjb6gQ=="
       let salt = recover val [as U8:
         0x5b; 0x6d; 0x99; 0x68; 0x9d; 0x12; 0x35; 0x8e
@@ -408,7 +408,7 @@ class \nodoc\ iso _TestPbkdf2Sha256OutputLength is Property1[USize]
     Generators.usize(1, 128)
 
   fun ref property(sample: USize, h: PropertyHelper) ? =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       h.assert_eq[USize](sample,
         Pbkdf2Sha256("p", "s", 1, sample)?.size())
     end
@@ -420,7 +420,7 @@ class \nodoc\ iso _TestPbkdf2Sha256Deterministic is Property1[USize]
     Generators.usize(1, 64)
 
   fun ref property(sample: USize, h: PropertyHelper) ? =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       h.assert_array_eq[U8](
         Pbkdf2Sha256("p", "s", 1, sample)?,
         Pbkdf2Sha256("p", "s", 1, sample)?)
@@ -453,7 +453,7 @@ class \nodoc\ iso _TestShake128OutputLength is Property1[USize]
     Generators.usize(1, 256)
 
   fun ref property(sample: USize, h: PropertyHelper) ? =>
-    ifdef "openssl_3.0.x" then
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       let d = Digest.shake128(sample)
       d.append("test")?
       h.assert_eq[USize](sample, d.final().size())
@@ -466,7 +466,7 @@ class \nodoc\ iso _TestShake256OutputLength is Property1[USize]
     Generators.usize(1, 256)
 
   fun ref property(sample: USize, h: PropertyHelper) ? =>
-    ifdef "openssl_3.0.x" then
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       let d = Digest.shake256(sample)
       d.append("test")?
       h.assert_eq[USize](sample, d.final().size())
@@ -479,7 +479,7 @@ class \nodoc\ iso _TestShake128XofPrefix is Property1[USize]
     Generators.usize(2, 256)
 
   fun ref property(sample: USize, h: PropertyHelper) ? =>
-    ifdef "openssl_3.0.x" then
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       let small_size = sample / 2
       let large_size = sample
 
@@ -502,7 +502,7 @@ class \nodoc\ iso _TestShake256XofPrefix is Property1[USize]
     Generators.usize(2, 256)
 
   fun ref property(sample: USize, h: PropertyHelper) ? =>
-    ifdef "openssl_3.0.x" then
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       let small_size = sample / 2
       let large_size = sample
 

--- a/ssl/crypto/crypto.pony
+++ b/ssl/crypto/crypto.pony
@@ -4,7 +4,7 @@ The crypto package provides cryptographic primitives built on OpenSSL:
 * One-shot hash functions (`MD5`, `SHA256`, etc.) and streaming digests
   (`Digest`)
 * HMAC message authentication (`HmacSha256`)
-* PBKDF2 key derivation (`Pbkdf2Sha256`, requires OpenSSL 1.1.x or 3.0.x)
+* PBKDF2 key derivation (`Pbkdf2Sha256`)
 * Cryptographically secure random bytes (`RandBytes`)
 * Constant-time comparison (`ConstantTimeCompare`)
 """

--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -3,12 +3,12 @@ use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:crypto"
 use "lib:bcrypt" if windows
 
-use @EVP_MD_CTX_new[Pointer[_EVPCTX]]() if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
+use @EVP_MD_CTX_new[Pointer[_EVPCTX]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @EVP_DigestInit_ex[I32](ctx: Pointer[_EVPCTX] tag, t: Pointer[_EVPMD], impl: USize)
 use @EVP_DigestUpdate[I32](ctx: Pointer[_EVPCTX] tag, d: Pointer[U8] tag, cnt: USize)
 use @EVP_DigestFinal_ex[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, s: Pointer[USize])
-use @EVP_DigestFinalXOF[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, len: USize) if "openssl_3.0.x"
-use @EVP_MD_CTX_free[None](ctx: Pointer[_EVPCTX]) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
+use @EVP_DigestFinalXOF[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, len: USize) if "openssl_3.0.x" or "openssl_4.0.x"
+use @EVP_MD_CTX_free[None](ctx: Pointer[_EVPCTX]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
 use @EVP_md5[Pointer[_EVPMD]]()
 use @EVP_ripemd160[Pointer[_EVPMD]]()
@@ -39,7 +39,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 16
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       compile_error "You must select an SSL version to use."
@@ -52,7 +52,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 20
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       compile_error "You must select an SSL version to use."
@@ -65,7 +65,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 20
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       compile_error "You must select an SSL version to use."
@@ -78,7 +78,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 28
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       compile_error "You must select an SSL version to use."
@@ -91,7 +91,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 32
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       compile_error "You must select an SSL version to use."
@@ -104,7 +104,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 48
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       compile_error "You must select an SSL version to use."
@@ -117,7 +117,7 @@ class Digest
     """
     _variable_length = false
     _digest_size = 64
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @EVP_MD_CTX_new()
     else
       compile_error "You must select an SSL version to use."
@@ -130,11 +130,11 @@ class Digest
 
     SHAKE128 is an extendable output function (XOF) that can produce
     variable-length output. The `size'` parameter controls the output length
-    in bytes (default: 16). Variable-length output requires OpenSSL 3.0.x;
-    on OpenSSL 1.1.x, the default size is always used.
+    in bytes (default: 16). Variable-length output requires OpenSSL 3.0.x or
+    OpenSSL 4.0.x; on OpenSSL 1.1.x, the default size is always used.
     """
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
-      ifdef "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
+      ifdef "openssl_3.0.x" or "openssl_4.0.x" then
         _variable_length = true
         _digest_size = size'
       else
@@ -144,7 +144,7 @@ class Digest
       _ctx = @EVP_MD_CTX_new()
       @EVP_DigestInit_ex(_ctx, @EVP_shake128(), USize(0))
     else
-      compile_error "shake128 is only supported with OpenSSL 1.1.x or 3.0.x"
+      compile_error "shake128 is only supported with OpenSSL 1.1.x, 3.0.x, or 4.0.x"
     end
 
   new shake256(size': USize = 32) =>
@@ -153,11 +153,11 @@ class Digest
 
     SHAKE256 is an extendable output function (XOF) that can produce
     variable-length output. The `size'` parameter controls the output length
-    in bytes (default: 32). Variable-length output requires OpenSSL 3.0.x;
-    on OpenSSL 1.1.x, the default size is always used.
+    in bytes (default: 32). Variable-length output requires OpenSSL 3.0.x or
+    OpenSSL 4.0.x; on OpenSSL 1.1.x, the default size is always used.
     """
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
-      ifdef "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
+      ifdef "openssl_3.0.x" or "openssl_4.0.x" then
         _variable_length = true
         _digest_size = size'
       else
@@ -167,7 +167,7 @@ class Digest
       _ctx = @EVP_MD_CTX_new()
       @EVP_DigestInit_ex(_ctx, @EVP_shake256(), USize(0))
     else
-      compile_error "shake256 is only supported with OpenSSL 1.1.x or 3.0.x"
+      compile_error "shake256 is only supported with OpenSSL 1.1.x, 3.0.x, or 4.0.x"
     end
 
   fun ref append(input: ByteSeq) ? =>
@@ -193,13 +193,13 @@ class Digest
       if not _variable_length then
         @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[USize])
       else
-        ifdef "openssl_3.0.x" then
+        ifdef "openssl_3.0.x" or "openssl_4.0.x" then
           @EVP_DigestFinalXOF(_ctx, digest.cpointer(), size)
         else
           @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[USize])
         end
       end
-      ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+      ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
         @EVP_MD_CTX_free(_ctx)
       else
         compile_error "You must select an SSL version to use."

--- a/ssl/crypto/pbkdf2_sha256.pony
+++ b/ssl/crypto/pbkdf2_sha256.pony
@@ -6,7 +6,7 @@ use @PKCS5_PBKDF2_HMAC[I32](
   pass: Pointer[U8] tag, passlen: I32,
   salt: Pointer[U8] tag, saltlen: I32, iter: I32,
   digest: Pointer[_EVPMD],
-  keylen: I32, out: Pointer[U8] tag) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
+  keylen: I32, out: Pointer[U8] tag) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
 primitive Pbkdf2Sha256
   """
@@ -16,8 +16,6 @@ primitive Pbkdf2Sha256
   Returns a key of the requested length, or raises an error if the derivation
   fails (e.g., zero iterations).
 
-  Supported on OpenSSL 1.1.x, OpenSSL 3.0.x, and LibreSSL.
-
   ```pony
   let key = Pbkdf2Sha256("password", "salt", 4096, 32)?
   ```
@@ -25,7 +23,7 @@ primitive Pbkdf2Sha256
   fun tag apply(password: ByteSeq, salt: ByteSeq, iterations: U32,
     key_length: USize): Array[U8] val ?
   =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       recover
         let arr = Array[U8].init(0, key_length)
         let rc = @PKCS5_PBKDF2_HMAC(

--- a/ssl/net/_ssl_init.pony
+++ b/ssl/net/_ssl_init.pony
@@ -20,7 +20,7 @@ primitive _SSLInit
   This initialises SSL when the program begins.
   """
   fun _init() =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
       let settings = @OPENSSL_INIT_new()
       @OPENSSL_init_ssl(
         _OpenSslInitLoadSslStrings() + _OpenSslInitLoadCryptoStrings(),

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -15,7 +15,7 @@ use @SSL_set_accept_state[None](ssl: Pointer[_SSL])
 use @SSL_set_connect_state[None](ssl: Pointer[_SSL])
 use @SSL_do_handshake[I32](ssl: Pointer[_SSL])
 use @SSL_get0_alpn_selected[None](ssl: Pointer[_SSL] tag, data: Pointer[Pointer[U8] iso],
-  len: Pointer[U32]) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
+  len: Pointer[U32]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @SSL_pending[I32](ssl: Pointer[_SSL])
 use @SSL_read[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: U32)
 use @SSL_write[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: U32)
@@ -23,9 +23,9 @@ use @BIO_read[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
 use @BIO_write[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
 use @SSL_get_error[I32](ssl: Pointer[_SSL], ret: I32)
 use @BIO_ctrl_pending[USize](bio: Pointer[_BIO] tag)
-use @SSL_has_pending[I32](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x"
+use @SSL_has_pending[I32](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @SSL_get_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "libressl"
-use @SSL_get1_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_3.0.x"
+use @SSL_get1_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_3.0.x" or "openssl_4.0.x"
 
 primitive _SSL
 primitive _BIO
@@ -100,7 +100,7 @@ class SSL
     """
     var ptr: Pointer[U8] iso = recover Pointer[U8] end
     var len = U32(0)
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       @SSL_get0_alpn_selected(_ssl, addressof ptr, addressof len)
     end
 
@@ -180,7 +180,7 @@ class SSL
       if @BIO_ctrl_pending(_input) > 0 then
         read(expect)
       else
-        ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+        ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
           // try and read again any data already decoded from SSL that hasn't
           // been read via `SSL_has_pending` that was added in 1.1
           // This mailing list post has a good description of what it is for:
@@ -262,7 +262,7 @@ class SSL
     Verify that the certificate is valid for the given hostname.
     """
     if _verify and (_hostname.size() > 0) then
-      let cert = ifdef "openssl_3.0.x" then
+      let cert = ifdef "openssl_3.0.x" or "openssl_4.0.x" then
         @SSL_get1_peer_certificate(_ssl)
       elseif "openssl_1.1.x" or "libressl" then
         @SSL_get_peer_certificate(_ssl)

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -10,11 +10,11 @@ use @SSL_CTX_ctrl[ILong](
   op: I32,
   arg: ULong,
   parg: Pointer[None])
-use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
+use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @SSL_CTX_new[Pointer[_SSLContext]](method: Pointer[None])
 use @SSL_CTX_free[None](ctx: Pointer[_SSLContext] tag)
-use @SSL_CTX_clear_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x"
-use @SSL_CTX_set_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x"
+use @SSL_CTX_clear_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_CTX_set_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @SSL_CTX_use_certificate_chain_file[I32](ctx: Pointer[_SSLContext] tag, file: Pointer[U8] tag)
 use @SSL_CTX_use_PrivateKey_file[I32](ctx: Pointer[_SSLContext] tag, file: Pointer[U8] tag, typ: I32)
 use @SSL_CTX_check_private_key[I32](ctx: Pointer[_SSLContext] tag)
@@ -35,9 +35,9 @@ use @CertCloseStore[Bool](store: Pointer[U8] tag, flags: U32) if windows
 use @SSL_CTX_set_cipher_list[I32](ctx: Pointer[_SSLContext] tag, control: Pointer[U8] tag)
 use @SSL_CTX_set_verify_depth[None](ctx: Pointer[_SSLContext] tag, depth: U32)
 use @SSL_CTX_set_alpn_select_cb[None](ctx: Pointer[_SSLContext] tag, cb: _ALPNSelectCallback,
-   resolver: ALPNProtocolResolver) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
+   resolver: ALPNProtocolResolver) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @SSL_CTX_set_alpn_protos[I32](ctx: Pointer[_SSLContext] tag, protos: Pointer[U8] tag,
-  protos_len: USize) if "openssl_1.1.x" or "openssl_3.0.x" or "libressl"
+  protos_len: USize) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
 primitive _SSLContext
 
@@ -68,7 +68,7 @@ class val SSLContext
     """
     Create an SSL context.
     """
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @SSL_CTX_new(@TLS_method())
 
       // Allow only newer ciphers.
@@ -81,7 +81,7 @@ class val SSLContext
     end
 
   fun _set_options(opts: ULong) =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
       @SSL_CTX_set_options(_ctx, opts)
     elseif "libressl" then
       @SSL_CTX_ctrl(_ctx, _SslCtrlSetOptions(), opts, Pointer[None])
@@ -90,7 +90,7 @@ class val SSLContext
     end
 
   fun _clear_options(opts: ULong) =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
       @SSL_CTX_clear_options(_ctx, opts)
     elseif "libressl" then
       @SSL_CTX_ctrl(_ctx, _SslCtrlClearOptions(), opts, Pointer[None])
@@ -293,9 +293,8 @@ class val SSLContext
     Use `resolver` to choose the protocol to be selected for incomming connections.
 
     Returns true on success.
-    Supported on OpenSSL 1.1.x, OpenSSL 3.0.x, and LibreSSL.
     """
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       @SSL_CTX_set_alpn_select_cb(
         _ctx, addressof SSLContext._alpn_select_cb, resolver)
       return true
@@ -309,9 +308,8 @@ class val SSLContext
     protocol names must have a size of 1 to 255
 
     Returns true on success.
-    Supported on OpenSSL 1.1.x, OpenSSL 3.0.x, and LibreSSL.
     """
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "libressl" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       try
         let proto_list = _ALPNProtocolList.from_array(protocols)?
         let result =

--- a/ssl/net/x509.pony
+++ b/ssl/net/x509.pony
@@ -8,7 +8,7 @@ use @X509_NAME_get_text_by_NID[I32](name: Pointer[_X509Name], nid: I32,
 use @X509_get_ext_d2i[Pointer[_GeneralNameStack]](cert: Pointer[X509],
   nid: I32, crit: Pointer[U8], idx: Pointer[U8])
 use @OPENSSL_sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
-  if "openssl_1.1.x" or "openssl_3.0.x"
+  if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
   if "libressl"
 use @GENERAL_NAME_get0_value[Pointer[U8] tag](name: Pointer[_GeneralName],
@@ -18,7 +18,7 @@ use @ASN1_STRING_get0_data[Pointer[U8]](value: Pointer[U8] tag)
 use @ASN1_STRING_length[I32](value: Pointer[U8] tag)
 use @GENERAL_NAME_free[None](name: Pointer[_GeneralName])
 use @OPENSSL_sk_free[None](stack: Pointer[_GeneralNameStack])
-  if "openssl_1.1.x" or "openssl_3.0.x"
+  if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @sk_free[None](stack: Pointer[_GeneralNameStack])
   if "libressl"
 
@@ -84,7 +84,7 @@ primitive X509
     end
 
     var name =
-      ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+      ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
         @OPENSSL_sk_pop(stack)
       elseif "libressl" then
         @sk_pop(stack)
@@ -130,7 +130,7 @@ primitive X509
       end
 
       @GENERAL_NAME_free(name)
-      ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+      ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
         name = @OPENSSL_sk_pop(stack)
       elseif "libressl" then
         name = @sk_pop(stack)
@@ -139,7 +139,7 @@ primitive X509
       end
     end
 
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" then
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
       @OPENSSL_sk_free(stack)
     elseif "libressl" then
       @sk_free(stack)


### PR DESCRIPTION
OpenSSL 4.0.0 was released in April 2026 and a `shared-docker-ci-standard-builder-with-openssl-4.0.0` image is now available. The builder configures OpenSSL with `--api=3.0.0`, preserving the 3.0 application API, so extending every `openssl_3.0.x` compile guard to also list `openssl_4.0.x` is sufficient to support the new backend at the FFI boundary.

Adds a new `-Dopenssl_4.0.x` define and a new `make ssl=4.0.x` option. CI runs the full test suite against OpenSSL 4.0.x on both the most-recent ponyc release and ponyc main.

Incidentally corrects a pre-existing docstring in `ssl/crypto/crypto.pony` that listed PBKDF2 as requiring only OpenSSL; LibreSSL has been supported since first-class LibreSSL support landed.

Closes #44