### PR TITLE
Remove stale references to make.ps1 libs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ sudo zypper install libopenssl-devel
 
 ### Installing on Windows
 
-If you use [Corral](https://github.com/ponylang/corral) to include this package as dependency of a project, Corral will download and build LibreSSL for you the first time you run `corral fetch`.  Otherwise, before using this package, you must run `.\make.ps1 libs` in its base directory to download and build LibreSSL for Windows. In both cases, you will need CMake (3.15 or higher) and 7Zip (`7z.exe`) in your `PATH`; and Visual Studio 2017 or later (or the Visual C++ Build Tools 2017 or later) installed in your system.
-
-You should pass `--define libressl` to Ponyc when using this package on Windows.
+Install one of the supported SSL libraries.
 
 ## API Documentation
 

--- a/corral.json
+++ b/corral.json
@@ -12,10 +12,5 @@
     "documentation_url": "https://ponylang.github.io/ssl",
     "version": "2.1.0",
     "name": "ssl"
-  },
-  "scripts": {
-    "windows": {
-      "post_fetch_or_update": "PowerShell.exe -File make.ps1 -Config release -Command libs"
-    }
   }
 }


### PR DESCRIPTION
PR #38 removed the `make.ps1 libs` command but left dangling references in two places: the README's Windows install section described a flow that no longer exists, and corral.json's `post_fetch_or_update` hook called the removed command.

Rewrites the Windows install section to match the brevity of the other platform sections, and removes the broken hook from corral.json.

Closes #51
Closes #37