### PR TITLE
Call out OpenSSL 1.1.x as legacy-only in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,9 @@ Production ready.
 
 ## Supported SSL versions
 
-OpenSSL 1.1.x, OpenSSL 3.0.x, OpenSSL 4.0.x, and LibreSSL are supported. Select the library version at compile-time using Pony's compile time definition functionality.
+OpenSSL 3.0.x, OpenSSL 4.0.x, LibreSSL, and OpenSSL 1.1.x are supported. Select the library version at compile-time using Pony's compile time definition functionality.
 
-### Using OpenSSL 1.1.x
-
-```bash
-corral run -- ponyc -Dopenssl_1.1.x
-```
+Not every supported backend is still actively maintained upstream. OpenSSL 1.1.x reached end-of-life in September 2023 and no longer receives public security fixes. It remains available here for legacy use only. OpenSSL 3.0.x, OpenSSL 4.0.x, and LibreSSL are actively maintained.
 
 ### Using OpenSSL 3.0.x
 
@@ -43,9 +39,15 @@ corral run -- ponyc -Dopenssl_4.0.x
 corral run -- ponyc -Dlibressl
 ```
 
+### Using OpenSSL 1.1.x (legacy)
+
+```bash
+corral run -- ponyc -Dopenssl_1.1.x
+```
+
 ## Dependencies
 
-`ssl` requires either LibreSSL or OpenSSL in order to operate. You'll might need to install it within your environment of choice.
+`ssl` requires either LibreSSL or OpenSSL in order to operate. You might need to install it within your environment of choice.
 
 ### Installing on APT based Linux distributions
 


### PR DESCRIPTION
The README listed four SSL backends with no steering. A user picking one had no signal about which still received upstream fixes.

OpenSSL 1.1.x reached end-of-life in September 2023 and gets no public security fixes; the other three (OpenSSL 3.0.x, OpenSSL 4.0.x, and LibreSSL) are actively maintained. Calls this out in the prose, marks the 1.1.x subsection heading as legacy, and puts it after the actively maintained backends.

Drive-by: fixes a pre-existing "You'll might" typo in Dependencies.

Closes #52