### PR TITLE
Close pre-existing ifdef / FFI guard gaps

### DIFF
--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -190,14 +190,16 @@ class Digest
         recover String.from_cpointer(
           @pony_alloc(@pony_ctx(), size), size)
         end
-      if not _variable_length then
-        @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[USize])
-      else
-        ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+      ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+        if _variable_length then
           @EVP_DigestFinalXOF(_ctx, digest.cpointer(), size)
         else
           @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[USize])
         end
+      elseif "openssl_1.1.x" or "libressl" then
+        @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[USize])
+      else
+        compile_error "You must select an SSL version to use."
       end
       ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
         @EVP_MD_CTX_free(_ctx)

--- a/ssl/net/_ssl_init.pony
+++ b/ssl/net/_ssl_init.pony
@@ -4,8 +4,11 @@ use "lib:ssl"
 use "lib:crypto"
 
 use @OPENSSL_init_ssl[I32](opts: U64, settings: Pointer[_OpenSslInitSettings])
+  if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @OPENSSL_INIT_new[Pointer[_OpenSslInitSettings]]()
+  if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @OPENSSL_INIT_free[None](settings: Pointer[_OpenSslInitSettings])
+  if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 
 primitive _OpenSslInitSettings
 

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -102,6 +102,8 @@ class SSL
     var len = U32(0)
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       @SSL_get0_alpn_selected(_ssl, addressof ptr, addressof len)
+    else
+      compile_error "You must select an SSL version to use."
     end
 
     if ptr.is_null() then None
@@ -177,18 +179,21 @@ class SSL
       _read_buf = []
     else
       // try and read again any pending data that SSL hasn't decoded yet
-      if @BIO_ctrl_pending(_input) > 0 then
-        read(expect)
-      else
-        ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
-          // try and read again any data already decoded from SSL that hasn't
-          // been read via `SSL_has_pending` that was added in 1.1
-          // This mailing list post has a good description of what it is for:
+      ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
+        if @BIO_ctrl_pending(_input) > 0 then
+          read(expect)
+        elseif @SSL_has_pending(_ssl) == 1 then
+          // SSL has buffered data that BIO_ctrl_pending cannot see.
           // https://mta.openssl.org/pipermail/openssl-users/2017-January/005110.html
-          if @SSL_has_pending(_ssl) == 1 then
-            read(expect)
-          end
+          read(expect)
         end
+      elseif "libressl" then
+        // LibreSSL does not expose SSL_has_pending.
+        if @BIO_ctrl_pending(_input) > 0 then
+          read(expect)
+        end
+      else
+        compile_error "You must select an SSL version to use."
       end
     end
 


### PR DESCRIPTION
Close the gaps called out in #50 plus a same-class pre-existing gap in `alpn_selected`: every `ifdef` chain now terminates in `compile_error`, and FFI `use` statements carry `if` guards matching their supporting backends.

The `ssl/net/ssl.pony` pending-bytes restructure is semantics-preserving on every backend; duplicating the `BIO_ctrl_pending` check across branches avoids an empty LibreSSL arm.

Closes #50