### PR TITLE
Migrate to the Pointer / UnsafePointer split

### DIFF
--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -3,22 +3,22 @@ use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:crypto"
 use "lib:bcrypt" if windows
 
-use @EVP_MD_CTX_new[Pointer[_EVPCTX]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
-use @EVP_DigestInit_ex[I32](ctx: Pointer[_EVPCTX] tag, t: Pointer[_EVPMD], impl: USize)
-use @EVP_DigestUpdate[I32](ctx: Pointer[_EVPCTX] tag, d: Pointer[U8] tag, cnt: USize)
-use @EVP_DigestFinal_ex[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, s: Pointer[USize])
-use @EVP_DigestFinalXOF[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, len: USize) if "openssl_3.0.x" or "openssl_4.0.x"
-use @EVP_MD_CTX_free[None](ctx: Pointer[_EVPCTX]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+use @EVP_MD_CTX_new[UnsafePointer[_EVPCTX]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+use @EVP_DigestInit_ex[I32](ctx: UnsafePointer[_EVPCTX] tag, t: UnsafePointer[_EVPMD], impl: USize)
+use @EVP_DigestUpdate[I32](ctx: UnsafePointer[_EVPCTX] tag, d: Pointer[U8] tag, cnt: USize)
+use @EVP_DigestFinal_ex[I32](ctx: UnsafePointer[_EVPCTX] tag, md: Pointer[U8] tag, s: Pointer[USize])
+use @EVP_DigestFinalXOF[I32](ctx: UnsafePointer[_EVPCTX] tag, md: Pointer[U8] tag, len: USize) if "openssl_3.0.x" or "openssl_4.0.x"
+use @EVP_MD_CTX_free[None](ctx: UnsafePointer[_EVPCTX]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
-use @EVP_md5[Pointer[_EVPMD]]()
-use @EVP_ripemd160[Pointer[_EVPMD]]()
-use @EVP_sha1[Pointer[_EVPMD]]()
-use @EVP_sha224[Pointer[_EVPMD]]()
-use @EVP_sha256[Pointer[_EVPMD]]()
-use @EVP_sha384[Pointer[_EVPMD]]()
-use @EVP_sha512[Pointer[_EVPMD]]()
-use @EVP_shake128[Pointer[_EVPMD]]()
-use @EVP_shake256[Pointer[_EVPMD]]()
+use @EVP_md5[UnsafePointer[_EVPMD]]()
+use @EVP_ripemd160[UnsafePointer[_EVPMD]]()
+use @EVP_sha1[UnsafePointer[_EVPMD]]()
+use @EVP_sha224[UnsafePointer[_EVPMD]]()
+use @EVP_sha256[UnsafePointer[_EVPMD]]()
+use @EVP_sha384[UnsafePointer[_EVPMD]]()
+use @EVP_sha512[UnsafePointer[_EVPMD]]()
+use @EVP_shake128[UnsafePointer[_EVPMD]]()
+use @EVP_shake256[UnsafePointer[_EVPMD]]()
 
 primitive _EVPMD
 primitive _EVPCTX
@@ -29,7 +29,7 @@ class Digest
   produce a final hash from the concatenation of the input with final().
   """
   let _digest_size: USize
-  let _ctx: Pointer[_EVPCTX]
+  let _ctx: UnsafePointer[_EVPCTX]
   let _variable_length: Bool
   var _hash: (Array[U8] val | None) = None
 

--- a/ssl/crypto/hmac_sha256.pony
+++ b/ssl/crypto/hmac_sha256.pony
@@ -3,7 +3,7 @@ use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:crypto"
 
 use @HMAC[Pointer[U8]](
-  evp_md: Pointer[_EVPMD],
+  evp_md: UnsafePointer[_EVPMD],
   key: Pointer[U8] tag, key_len: I32,
   data: Pointer[U8] tag, data_len: USize,
   md: Pointer[U8] tag, md_len: Pointer[U32])

--- a/ssl/crypto/pbkdf2_sha256.pony
+++ b/ssl/crypto/pbkdf2_sha256.pony
@@ -5,7 +5,7 @@ use "lib:crypto"
 use @PKCS5_PBKDF2_HMAC[I32](
   pass: Pointer[U8] tag, passlen: I32,
   salt: Pointer[U8] tag, saltlen: I32, iter: I32,
-  digest: Pointer[_EVPMD],
+  digest: UnsafePointer[_EVPMD],
   keylen: I32, out: Pointer[U8] tag) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
 primitive Pbkdf2Sha256

--- a/ssl/net/_ssl_init.pony
+++ b/ssl/net/_ssl_init.pony
@@ -3,11 +3,11 @@ use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:ssl"
 use "lib:crypto"
 
-use @OPENSSL_init_ssl[I32](opts: U64, settings: Pointer[_OpenSslInitSettings])
+use @OPENSSL_init_ssl[I32](opts: U64, settings: UnsafePointer[_OpenSslInitSettings])
   if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
-use @OPENSSL_INIT_new[Pointer[_OpenSslInitSettings]]()
+use @OPENSSL_INIT_new[UnsafePointer[_OpenSslInitSettings]]()
   if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
-use @OPENSSL_INIT_free[None](settings: Pointer[_OpenSslInitSettings])
+use @OPENSSL_INIT_free[None](settings: UnsafePointer[_OpenSslInitSettings])
   if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 
 primitive _OpenSslInitSettings
@@ -30,7 +30,7 @@ primitive _SSLInit
         settings)
       @OPENSSL_INIT_free(settings)
     elseif "libressl" then
-      @OPENSSL_init_ssl(0, Pointer[_OpenSslInitSettings])
+      @OPENSSL_init_ssl(0, UnsafePointer[_OpenSslInitSettings])
     else
       compile_error "You must select an SSL version to use."
     end

--- a/ssl/net/alpn.pony
+++ b/ssl/net/alpn.pony
@@ -10,10 +10,10 @@ primitive ALPNWarning
 
 type ALPNMatchResult is (ALPNProtocolName | ALPNNoAck | ALPNWarning | ALPNFatal)
 type _ALPNSelectCallback is @{(
-   Pointer[_SSL] tag,
-   Pointer[Pointer[U8] tag] tag,
-   Pointer[U8] tag,
-   Pointer[U8] box,
+   UnsafePointer[_SSL] tag,
+   UnsafePointer[Pointer[U8] tag] tag,
+   UnsafePointer[U8] tag,
+   UnsafePointer[U8] box,
    U32,
    ALPNProtocolResolver box)
   : I32}

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -1,31 +1,32 @@
 use "net"
 
 use @SSL_ctrl[ILong](
-  ssl: Pointer[_SSL],
+  ssl: UnsafePointer[_SSL],
   op: I32,
   arg: ILong,
   parg: Pointer[None])
-use @SSL_new[Pointer[_SSL]](ctx: Pointer[_SSLContext] tag)
-use @SSL_free[None](ssl: Pointer[_SSL] tag)
-use @SSL_set_verify[None](ssl: Pointer[_SSL], mode: I32, cb: Pointer[U8])
-use @BIO_s_mem[Pointer[U8]]()
-use @BIO_new[Pointer[_BIO]](typ: Pointer[U8])
-use @SSL_set_bio[None](ssl: Pointer[_SSL], rbio: Pointer[_BIO] tag, wbio: Pointer[_BIO] tag)
-use @SSL_set_accept_state[None](ssl: Pointer[_SSL])
-use @SSL_set_connect_state[None](ssl: Pointer[_SSL])
-use @SSL_do_handshake[I32](ssl: Pointer[_SSL])
-use @SSL_get0_alpn_selected[None](ssl: Pointer[_SSL] tag, data: Pointer[Pointer[U8] iso],
+use @SSL_new[UnsafePointer[_SSL]](ctx: UnsafePointer[_SSLContext] tag)
+use @SSL_free[None](ssl: UnsafePointer[_SSL] tag)
+use @SSL_set_verify[None](ssl: UnsafePointer[_SSL], mode: I32,
+  cb: UnsafePointer[U8])
+use @BIO_s_mem[UnsafePointer[U8]]()
+use @BIO_new[UnsafePointer[_BIO]](typ: UnsafePointer[U8])
+use @SSL_set_bio[None](ssl: UnsafePointer[_SSL], rbio: UnsafePointer[_BIO] tag, wbio: UnsafePointer[_BIO] tag)
+use @SSL_set_accept_state[None](ssl: UnsafePointer[_SSL])
+use @SSL_set_connect_state[None](ssl: UnsafePointer[_SSL])
+use @SSL_do_handshake[I32](ssl: UnsafePointer[_SSL])
+use @SSL_get0_alpn_selected[None](ssl: UnsafePointer[_SSL] tag, data: Pointer[UnsafePointer[U8] iso],
   len: Pointer[U32]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
-use @SSL_pending[I32](ssl: Pointer[_SSL])
-use @SSL_read[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: U32)
-use @SSL_write[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: U32)
-use @BIO_read[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
-use @BIO_write[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
-use @SSL_get_error[I32](ssl: Pointer[_SSL], ret: I32)
-use @BIO_ctrl_pending[USize](bio: Pointer[_BIO] tag)
-use @SSL_has_pending[I32](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
-use @SSL_get_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "libressl"
-use @SSL_get1_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_pending[I32](ssl: UnsafePointer[_SSL])
+use @SSL_read[I32](ssl: UnsafePointer[_SSL], buf: Pointer[U8] tag, len: U32)
+use @SSL_write[I32](ssl: UnsafePointer[_SSL], buf: Pointer[U8] tag, len: U32)
+use @BIO_read[I32](bio: UnsafePointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
+use @BIO_write[I32](bio: UnsafePointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
+use @SSL_get_error[I32](ssl: UnsafePointer[_SSL], ret: I32)
+use @BIO_ctrl_pending[USize](bio: UnsafePointer[_BIO] tag)
+use @SSL_has_pending[I32](ssl: UnsafePointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_get_peer_certificate[UnsafePointer[X509]](ssl: UnsafePointer[_SSL]) if "openssl_1.1.x" or "libressl"
+use @SSL_get1_peer_certificate[UnsafePointer[X509]](ssl: UnsafePointer[_SSL]) if "openssl_3.0.x" or "openssl_4.0.x"
 
 primitive _SSL
 primitive _BIO
@@ -44,14 +45,14 @@ class SSL
   """
   let _hostname: String
   let _verify: Bool
-  var _ssl: Pointer[_SSL]
-  var _input: Pointer[_BIO] tag
-  var _output: Pointer[_BIO] tag
+  var _ssl: UnsafePointer[_SSL]
+  var _input: UnsafePointer[_BIO] tag
+  var _output: UnsafePointer[_BIO] tag
   var _state: SSLState = SSLHandshake
   var _read_buf: Array[U8] iso = []
 
   new _create(
-    ctx: Pointer[_SSLContext] tag,
+    ctx: UnsafePointer[_SSLContext] tag,
     server: Bool,
     verify: Bool,
     hostname: String = "")
@@ -68,7 +69,7 @@ class SSL
     if _ssl.is_null() then error end
 
     let mode = if verify then I32(3) else I32(0) end
-    @SSL_set_verify(_ssl, mode, Pointer[U8])
+    @SSL_set_verify(_ssl, mode, UnsafePointer[U8])
 
     _input = @BIO_new(@BIO_s_mem())
     if _input.is_null() then error end
@@ -98,7 +99,7 @@ class SSL
     """
     Get the protocol identifier negotiated via ALPN
     """
-    var ptr: Pointer[U8] iso = recover Pointer[U8] end
+    var ptr: UnsafePointer[U8] iso = recover UnsafePointer[U8] end
     var len = U32(0)
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       @SSL_get0_alpn_selected(_ssl, addressof ptr, addressof len)
@@ -251,7 +252,7 @@ class SSL
     """
     if not _ssl.is_null() then
       @SSL_free(_ssl)
-      _ssl = Pointer[_SSL]
+      _ssl = UnsafePointer[_SSL]
     end
 
   fun _final() =>

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -4,39 +4,39 @@ use "lib:crypt32" if windows
 use "lib:cryptui" if windows
 use "lib:bcrypt" if windows
 
-use @memcpy[Pointer[U8]](dst: Pointer[None], src: Pointer[None], n: USize)
+use @memcpy[Pointer[U8]](dst: UnsafePointer[None], src: Pointer[None], n: USize)
 use @SSL_CTX_ctrl[ILong](
-  ctx: Pointer[_SSLContext] tag,
+  ctx: UnsafePointer[_SSLContext] tag,
   op: I32,
   arg: ULong,
   parg: Pointer[None])
-use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
-use @SSL_CTX_new[Pointer[_SSLContext]](method: Pointer[None])
-use @SSL_CTX_free[None](ctx: Pointer[_SSLContext] tag)
-use @SSL_CTX_clear_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
-use @SSL_CTX_set_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
-use @SSL_CTX_use_certificate_chain_file[I32](ctx: Pointer[_SSLContext] tag, file: Pointer[U8] tag)
-use @SSL_CTX_use_PrivateKey_file[I32](ctx: Pointer[_SSLContext] tag, file: Pointer[U8] tag, typ: I32)
-use @SSL_CTX_check_private_key[I32](ctx: Pointer[_SSLContext] tag)
-use @SSL_CTX_load_verify_locations[I32](ctx: Pointer[_SSLContext] tag, ca_file: Pointer[U8] tag,
+use @TLS_method[UnsafePointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+use @SSL_CTX_new[UnsafePointer[_SSLContext]](method: UnsafePointer[None])
+use @SSL_CTX_free[None](ctx: UnsafePointer[_SSLContext] tag)
+use @SSL_CTX_clear_options[ULong](ctx: UnsafePointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_CTX_set_options[ULong](ctx: UnsafePointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_CTX_use_certificate_chain_file[I32](ctx: UnsafePointer[_SSLContext] tag, file: Pointer[U8] tag)
+use @SSL_CTX_use_PrivateKey_file[I32](ctx: UnsafePointer[_SSLContext] tag, file: Pointer[U8] tag, typ: I32)
+use @SSL_CTX_check_private_key[I32](ctx: UnsafePointer[_SSLContext] tag)
+use @SSL_CTX_load_verify_locations[I32](ctx: UnsafePointer[_SSLContext] tag, ca_file: Pointer[U8] tag,
   ca_path: Pointer[U8] tag)
 use @X509_STORE_new[Pointer[U8] tag]()
 use @CertOpenSystemStoreA[Pointer[U8] tag](prov: Pointer[U8] tag, protcol: Pointer[U8] tag)
   if windows
 use @CertEnumCertificatesInStore[NullablePointer[_CertContext]](cert_store: Pointer[U8] tag,
   prev_ctx: NullablePointer[_CertContext]) if windows
-use @d2i_X509[Pointer[X509] tag](val_out: Pointer[U8] tag, der_in: Pointer[Pointer[U8]],
+use @d2i_X509[UnsafePointer[X509] tag](val_out: Pointer[U8] tag, der_in: Pointer[Pointer[U8]],
   length: U32)
-use @X509_STORE_add_cert[U32](store: Pointer[U8] tag, x509: Pointer[X509] tag)
-use @X509_free[None](x509: Pointer[X509] tag)
-use @SSL_CTX_set_cert_store[None](ctx: Pointer[_SSLContext] tag, store: Pointer[U8] tag)
+use @X509_STORE_add_cert[U32](store: Pointer[U8] tag, x509: UnsafePointer[X509] tag)
+use @X509_free[None](x509: UnsafePointer[X509] tag)
+use @SSL_CTX_set_cert_store[None](ctx: UnsafePointer[_SSLContext] tag, store: Pointer[U8] tag)
 use @X509_STORE_free[None](store: Pointer[U8] tag)
 use @CertCloseStore[Bool](store: Pointer[U8] tag, flags: U32) if windows
-use @SSL_CTX_set_cipher_list[I32](ctx: Pointer[_SSLContext] tag, control: Pointer[U8] tag)
-use @SSL_CTX_set_verify_depth[None](ctx: Pointer[_SSLContext] tag, depth: U32)
-use @SSL_CTX_set_alpn_select_cb[None](ctx: Pointer[_SSLContext] tag, cb: _ALPNSelectCallback,
+use @SSL_CTX_set_cipher_list[I32](ctx: UnsafePointer[_SSLContext] tag, control: Pointer[U8] tag)
+use @SSL_CTX_set_verify_depth[None](ctx: UnsafePointer[_SSLContext] tag, depth: U32)
+use @SSL_CTX_set_alpn_select_cb[None](ctx: UnsafePointer[_SSLContext] tag, cb: _ALPNSelectCallback,
    resolver: ALPNProtocolResolver) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
-use @SSL_CTX_set_alpn_protos[I32](ctx: Pointer[_SSLContext] tag, protos: Pointer[U8] tag,
+use @SSL_CTX_set_alpn_protos[I32](ctx: UnsafePointer[_SSLContext] tag, protos: Pointer[U8] tag,
   protos_len: USize) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
 primitive _SSLContext
@@ -60,7 +60,7 @@ class val SSLContext
   """
   An SSL context is used to create SSL sessions.
   """
-  var _ctx: Pointer[_SSLContext] tag
+  var _ctx: UnsafePointer[_SSLContext] tag
   var _client_verify: Bool = true
   var _server_verify: Bool = false
 
@@ -324,10 +324,10 @@ class val SSLContext
     false
 
   fun @_alpn_select_cb(
-    ssl: Pointer[_SSL] tag,
-    out: Pointer[Pointer[U8] tag] tag,
-    outlen: Pointer[U8] tag,
-    inptr: Pointer[U8] box,
+    ssl: UnsafePointer[_SSL] tag,
+    out: UnsafePointer[Pointer[U8] tag] tag,
+    outlen: UnsafePointer[U8] tag,
+    inptr: UnsafePointer[U8] box,
     inlen: U32,
     resolver: ALPNProtocolResolver box)
     : I32
@@ -400,7 +400,7 @@ class val SSLContext
     """
     if not _ctx.is_null() then
       @SSL_CTX_free(_ctx)
-      _ctx = Pointer[_SSLContext]
+      _ctx = UnsafePointer[_SSLContext]
     end
 
   fun _final() =>

--- a/ssl/net/x509.pony
+++ b/ssl/net/x509.pony
@@ -1,25 +1,25 @@
 use "collections"
 use "net"
 
-use @pony_os_ip_string[Pointer[U8]](src: Pointer[U8], len: I32)
-use @X509_get_subject_name[Pointer[_X509Name]](cert: Pointer[X509])
-use @X509_NAME_get_text_by_NID[I32](name: Pointer[_X509Name], nid: I32,
+use @pony_os_ip_string[Pointer[U8]](src: UnsafePointer[U8], len: I32)
+use @X509_get_subject_name[UnsafePointer[_X509Name]](cert: UnsafePointer[X509])
+use @X509_NAME_get_text_by_NID[I32](name: UnsafePointer[_X509Name], nid: I32,
   buf: Pointer[U8] tag, len: I32)
-use @X509_get_ext_d2i[Pointer[_GeneralNameStack]](cert: Pointer[X509],
-  nid: I32, crit: Pointer[U8], idx: Pointer[U8])
-use @OPENSSL_sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
+use @X509_get_ext_d2i[UnsafePointer[_GeneralNameStack]](cert: UnsafePointer[X509],
+  nid: I32, crit: UnsafePointer[U8], idx: UnsafePointer[U8])
+use @OPENSSL_sk_pop[UnsafePointer[_GeneralName]](stack: UnsafePointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
-use @sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
+use @sk_pop[UnsafePointer[_GeneralName]](stack: UnsafePointer[_GeneralNameStack])
   if "libressl"
-use @GENERAL_NAME_get0_value[Pointer[U8] tag](name: Pointer[_GeneralName],
+use @GENERAL_NAME_get0_value[UnsafePointer[U8] tag](name: UnsafePointer[_GeneralName],
   ptype: Pointer[I32])
-use @ASN1_STRING_type[I32](value: Pointer[U8] tag)
-use @ASN1_STRING_get0_data[Pointer[U8]](value: Pointer[U8] tag)
-use @ASN1_STRING_length[I32](value: Pointer[U8] tag)
-use @GENERAL_NAME_free[None](name: Pointer[_GeneralName])
-use @OPENSSL_sk_free[None](stack: Pointer[_GeneralNameStack])
+use @ASN1_STRING_type[I32](value: UnsafePointer[U8] tag)
+use @ASN1_STRING_get0_data[UnsafePointer[U8]](value: UnsafePointer[U8] tag)
+use @ASN1_STRING_length[I32](value: UnsafePointer[U8] tag)
+use @GENERAL_NAME_free[None](name: UnsafePointer[_GeneralName])
+use @OPENSSL_sk_free[None](stack: UnsafePointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
-use @sk_free[None](stack: Pointer[_GeneralNameStack])
+use @sk_free[None](stack: UnsafePointer[_GeneralNameStack])
   if "libressl"
 
 primitive _X509Name
@@ -27,7 +27,7 @@ primitive _GeneralName
 primitive _GeneralNameStack
 
 primitive X509
-  fun valid_for_host(cert: Pointer[X509], host: String): Bool =>
+  fun valid_for_host(cert: UnsafePointer[X509], host: String): Bool =>
     """
     Checks if an OpenSSL X509 certificate is valid for a given host.
     """
@@ -38,7 +38,7 @@ primitive X509
     end
     false
 
-  fun common_name(cert: Pointer[X509]): String ? =>
+  fun common_name(cert: UnsafePointer[X509]): String ? =>
     """
     Get the common name for the certificate. Raises an error if the common name
     contains any NULL bytes.
@@ -60,7 +60,7 @@ primitive X509
 
     common
 
-  fun all_names(cert: Pointer[X509]): Array[String] val =>
+  fun all_names(cert: UnsafePointer[X509]): Array[String] val =>
     """
     Returns an array of all names for the certificate. Any names containing
     NULL bytes are not included. This includes the common name and all subject
@@ -77,7 +77,7 @@ primitive X509
     end
 
     let stack =
-      @X509_get_ext_d2i(cert, I32(85), Pointer[U8], Pointer[U8])
+      @X509_get_ext_d2i(cert, I32(85), UnsafePointer[U8], UnsafePointer[U8])
 
     if stack.is_null() then
       return array


### PR DESCRIPTION
The downstream side of the `Pointer`/`UnsafePointer` split. OpenSSL handles like `SSL*`, `BIO*`, and `X509*` become `UnsafePointer`, and so does the foreign data we copy into Pony strings (ASN1 certificate fields, ALPN protocol names). The read and write buffers we hand OpenSSL stay `Pointer`, because that memory is ours. One case shows both at once: `pony_os_ip_string` takes a foreign source but hands back `pony_alloc`'d memory we adopt, so its argument is `UnsafePointer` and its return is `Pointer`, in the same call.

It builds and passes all 54 tests against a ponyc carrying the split (ponylang/ponyc#5431). It will not build against released ponyc, so CI here stays red until the compiler change lands. That is expected for a draft.

This is for Joe and me to review alongside the compiler PR. The Windows certificate-store paths are left on `Pointer` for now, since they do not compile or run on the box I did this on.

Design: ponylang/ponyc#5427
