### PR TITLE
Fix crash when using a disposed SSL session and add SSLDisposed

### DIFF
--- a/.release-notes/fix-crash-using-disposed-ssl-session.md
+++ b/.release-notes/fix-crash-using-disposed-ssl-session.md
@@ -1,9 +1,0 @@
-## Fix crash when using a disposed SSL session
-
-Calling `read`, `receive`, `can_send`, or `send` on an `SSL` session that had already been disposed crashed the program.
-
-A disposed session is now inert. `read` returns `None`, `receive` does nothing, `can_send` returns `false`, `alpn_selected` returns `None`, and `write` and `send` raise an error. `state` is the one exception: it keeps returning the state the session was in when it was disposed.
-
-Two behavior changes come with the crash fix. `write` on a disposed session used to return as though it had written the data, and nothing was written; it now raises an error. `read` on a disposed session that still held decrypted bytes from an incomplete `expect` frame used to hand those bytes back; it now returns `None`.
-
-Anything built on `SSLConnection` is unaffected: it wraps every `write` in a `try`, and it disposes a session only once the connection has closed and stopped reading. Code that uses `SSL` directly and discards the error from `write` was silently dropping data and now gets an error.

--- a/.release-notes/fix-crash-using-disposed-ssl-session.md
+++ b/.release-notes/fix-crash-using-disposed-ssl-session.md
@@ -1,0 +1,9 @@
+## Fix crash when using a disposed SSL session
+
+Calling `read`, `receive`, `can_send`, or `send` on an `SSL` session that had already been disposed crashed the program.
+
+A disposed session is now inert. `read` returns `None`, `receive` does nothing, `can_send` returns `false`, `alpn_selected` returns `None`, and `write` and `send` raise an error. `state` is the one exception: it keeps returning the state the session was in when it was disposed.
+
+Two behavior changes come with the crash fix. `write` on a disposed session used to return as though it had written the data, and nothing was written; it now raises an error. `read` on a disposed session that still held decrypted bytes from an incomplete `expect` frame used to hand those bytes back; it now returns `None`.
+
+Anything built on `SSLConnection` is unaffected: it wraps every `write` in a `try`, and it disposes a session only once the connection has closed and stopped reading. Code that uses `SSL` directly and discards the error from `write` was silently dropping data and now gets an error.

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,38 @@
+## Fix crash when using a disposed SSL session
+
+Calling `read`, `receive`, `can_send`, or `send` on an `SSL` session that had already been disposed crashed the program.
+
+A disposed session is now inert. `read` returns `None`, `receive` and `write` do nothing, `can_send` returns `false`, `alpn_selected` returns `None`, and `send` raises an error, the same as it does for any session with nothing left to send.
+
+`read` on a disposed session that still held decrypted bytes from an incomplete `expect` frame used to hand those bytes back. It now returns `None`, like every other read of a disposed session.
+
+## Add SSLDisposed to SSLState
+
+`SSL.state()` used to keep returning the state a session was in when it was disposed. A session that finished its handshake and was then disposed still reported `SSLReady`, so no part of the API distinguished a freed session from a live one.
+
+`SSLState` has a new member, `SSLDisposed`. `SSL.dispose()` puts the session in it, whatever state the session was in before.
+
+Code that wraps a protocol in `SSLConnection` needs no change; we updated `SSLConnection` for the new state.
+
+Code that matches on `SSL.state()` exhaustively needs a new branch:
+
+```pony
+// Before
+match \exhaustive\ ssl.state()
+| SSLHandshake => None
+| SSLAuthFail => None
+| SSLReady => None
+| SSLError => None
+end
+
+// After
+match \exhaustive\ ssl.state()
+| SSLHandshake => None
+| SSLAuthFail => None
+| SSLReady => None
+| SSLError => None
+| SSLDisposed => None
+end
+```
+
+Code that read `state()` after a dispose to recover the state the session was in before no longer can. `state()` reports `SSLDisposed` from that point on. Read the state before disposing the session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix crash when using a disposed SSL session ([PR #68](https://github.com/ponylang/ssl/pull/68))
 
 ### Added
 
 
 ### Changed
 
+- Add SSLDisposed to SSLState ([PR #68](https://github.com/ponylang/ssl/pull/68))
 
 ## [2.1.0] - 2026-04-20
 

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -12,6 +12,16 @@ actor \nodoc\ Main is TestList
     test(_TestALPNProtocolListEncoding)
     test(_TestALPNProtocolListDecode)
     test(_TestALPNStandardProtocolResolver)
+    test(_TestSSLHandshakeInMemory)
+    test(_TestSSLDisposeBeforeHandshake)
+    test(_TestSSLDisposeTwice)
+    test(_TestSSLReadAfterDispose)
+    test(_TestSSLReadAfterDisposeWithBufferedFrame)
+    test(_TestSSLReceiveAfterDispose)
+    test(_TestSSLCanSendAfterDispose)
+    test(_TestSSLSendAfterDispose)
+    test(_TestSSLWriteAfterDispose)
+    test(_TestSSLALPNSelectedAfterDispose)
     test(_TestTCPSSLWritev)
     test(_TestTCPSSLExpect)
     test(_TestTCPSSLMute)
@@ -973,6 +983,489 @@ primitive \nodoc\ _TestSSLContext
       end
 
     (consume ssl_client, consume ssl_server)
+
+primitive \nodoc\ _TestSSLTransfer
+  fun val apply(sender: SSL, receiver: SSL) ? =>
+    """
+    Hand every encrypted byte the sender has ready over to the receiver, the
+    way a transport would.
+    """
+    while sender.can_send() do
+      receiver.receive(sender.send()?)
+    end
+
+primitive \nodoc\ _TestSSLSessionPair
+  fun val apply(h: TestHelper): (SSL, SSL) ? =>
+    """
+    A handshaken client and server session from the standard test context,
+    with no transport between them.
+    """
+    (let client, let server) = fresh(h)?
+    _handshake(h, client, server)?
+    (client, server)
+
+  fun val fresh(h: TestHelper): (SSL, SSL) ? =>
+    """
+    A client and a server session from the standard test context, before any
+    handshake. Both are in `SSLHandshake`.
+    """
+    (let client_session, let server_session) = _TestSSLContext(h)?
+    let client: SSL = consume client_session
+    let server: SSL = consume server_session
+    (client, server)
+
+  fun val from_context(h: TestHelper, sslctx: SSLContext val): (SSL, SSL) ? =>
+    """
+    A handshaken client and server session from `sslctx`, with no transport
+    between them.
+    """
+    let client: SSL =
+      try
+        sslctx.client()?
+      else
+        h.fail("failed getting ssl client session")
+        error
+      end
+    let server: SSL =
+      try
+        sslctx.server()?
+      else
+        h.fail("failed getting ssl server session")
+        error
+      end
+    _handshake(h, client, server)?
+    (client, server)
+
+  fun val _handshake(h: TestHelper, client: SSL, server: SSL) ? =>
+    """
+    Drive a handshake to completion by handing each side's outgoing bytes
+    straight to the other. Reports the reason and raises an error if the
+    handshake does not finish.
+    """
+    // How many rounds a handshake takes depends on the TLS version and the
+    // backend, so this is a backstop against a session that never settles,
+    // not a count anything should rely on.
+    let max_rounds: USize = 20
+    var rounds: USize = 0
+
+    while
+      (client.state() is SSLHandshake) or (server.state() is SSLHandshake)
+    do
+      if rounds == max_rounds then
+        h.fail(
+          "in memory SSL handshake did not finish in "
+            + max_rounds.string() + " rounds")
+        error
+      end
+      rounds = rounds + 1
+
+      _TestSSLTransfer(client, server)?
+      _TestSSLTransfer(server, client)?
+    end
+
+    if (client.state() isnt SSLReady) or (server.state() isnt SSLReady) then
+      h.fail("in memory SSL handshake did not reach SSLReady")
+      error
+    end
+
+class \nodoc\ iso _TestSSLHandshakeInMemory is UnitTest
+  """
+  Two SSL sessions can complete a handshake with no transport between them by
+  handing each side's outgoing bytes straight to the other, and application
+  data written by one can be read by the other.
+
+  The `after_dispose` tests all start from a handshaken pair. This test
+  verifies that the pair really handshakes and really moves data, so when one
+  of those tests fails, the session under test is at fault and not the
+  harness.
+  """
+  fun name(): String => "net/ssl/SSL/handshake_in_memory"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    h.assert_true(client.state() is SSLReady, "client is not SSLReady")
+    h.assert_true(server.state() is SSLReady, "server is not SSLReady")
+
+    try
+      client.write("hello")?
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("client could not send application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    match server.read()
+    | let data: Array[U8] iso =>
+      h.assert_eq[String]("hello", String.from_array(consume data))
+    | None =>
+      h.fail("server read no application data")
+    end
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLDisposeBeforeHandshake is UnitTest
+  """
+  A session disposed before its handshake finishes is inert too, and `state`
+  keeps returning `SSLHandshake`. This is the case from issue #66: a fresh
+  client session, disposed, then read.
+
+  A fresh client session has a ClientHello waiting to go out, so `can_send`
+  returning `false` after the dispose is the disposed check and not an empty
+  BIO.
+  """
+  fun name(): String => "net/ssl/SSL.dispose/before_handshake"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.fresh(h)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      client.state() is SSLHandshake,
+      "a fresh client session should be in SSLHandshake")
+    h.assert_true(
+      client.can_send(),
+      "a fresh client session should have a ClientHello to send")
+
+    client.dispose()
+
+    h.assert_true(
+      client.state() is SSLHandshake,
+      "dispose() should not change the session state")
+    h.assert_true(
+      client.read() is None,
+      "read() on a disposed session should return None")
+    h.assert_false(
+      client.can_send(),
+      "can_send() on a disposed session should return false")
+
+    client.receive("bytes that will never be decrypted")
+
+    try
+      client.send()?
+      h.fail("send() on a disposed session should raise an error")
+    end
+
+    server.dispose()
+
+class \nodoc\ iso _TestSSLDisposeTwice is UnitTest
+  """
+  Disposing a session twice does not free the session or its BIOs twice, and
+  the session is still inert afterwards.
+  """
+  fun name(): String => "net/ssl/SSL.dispose/twice"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    client.dispose()
+    client.dispose()
+
+    h.assert_true(
+      client.read() is None,
+      "read() on a disposed session should return None")
+    h.assert_false(
+      client.can_send(),
+      "can_send() on a disposed session should return false")
+
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReadAfterDispose is UnitTest
+  """
+  `read` on a disposed session returns `None` instead of passing a null
+  `SSL*` to `SSL_pending`.
+  """
+  fun name(): String => "net/ssl/SSL.read/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    client.dispose()
+
+    h.assert_true(
+      client.read() is None,
+      "read() on a disposed session should return None")
+    h.assert_true(
+      client.read(4) is None,
+      "read(4) on a disposed session should return None")
+
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReadAfterDisposeWithBufferedFrame is UnitTest
+  """
+  A session holding decrypted bytes from an incomplete `expect` frame returns
+  `None` from `read` once it is disposed, rather than handing those bytes
+  back.
+
+  This is the one post-dispose read that did not crash before the fix. With
+  at least `expect` bytes already buffered, `read` returns them without
+  touching the freed session.
+  """
+  fun name(): String => "net/ssl/SSL.read/after_dispose_with_buffered_frame"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    try
+      client.write("ab")?
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("client could not send application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      server.read(4) is None,
+      "two bytes should not satisfy read(4)")
+
+    server.dispose()
+
+    h.assert_true(
+      server.read(2) is None,
+      "read(2) on a disposed session should return None, even with two bytes "
+        + "already buffered")
+
+    client.dispose()
+
+class \nodoc\ iso _TestSSLReceiveAfterDispose is UnitTest
+  """
+  `receive` on a disposed session does nothing instead of writing into a freed
+  BIO. There is nothing to observe afterwards beyond the session still reading
+  as empty.
+  """
+  fun name(): String => "net/ssl/SSL.receive/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    server.dispose()
+    server.receive("bytes that will never be decrypted")
+
+    h.assert_true(
+      server.read() is None,
+      "a disposed session has nothing to read")
+
+    client.dispose()
+
+class \nodoc\ iso _TestSSLCanSendAfterDispose is UnitTest
+  """
+  `can_send` on a disposed session returns `false` instead of reading a freed
+  BIO.
+
+  The session has encrypted bytes waiting when it is disposed, so a `false`
+  here is the disposed check and not an empty BIO. A live session with nothing
+  to send returns `false` too.
+  """
+  fun name(): String => "net/ssl/SSL.can_send/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    try
+      client.write("data")?
+    else
+      h.fail("client could not write application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      client.can_send(),
+      "a session that has just written should have bytes to send")
+
+    client.dispose()
+
+    h.assert_false(
+      client.can_send(),
+      "can_send() on a disposed session should return false")
+
+    server.dispose()
+
+class \nodoc\ iso _TestSSLSendAfterDispose is UnitTest
+  """
+  `send` on a disposed session raises an error instead of reading a freed BIO.
+
+  The session has encrypted bytes waiting when it is disposed, so the error
+  here is the disposed check and not the empty BIO check.
+  """
+  fun name(): String => "net/ssl/SSL.send/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    try
+      client.write("data")?
+    else
+      h.fail("client could not write application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      client.can_send(),
+      "a session that has just written should have bytes to send")
+
+    client.dispose()
+
+    try
+      client.send()?
+      h.fail("send() on a disposed session should raise an error")
+    end
+
+    server.dispose()
+
+class \nodoc\ iso _TestSSLWriteAfterDispose is UnitTest
+  """
+  `write` on a disposed session raises an error. Before the fix it returned as
+  though the data had been written, and nothing was written.
+
+  The session is `SSLReady` before the dispose and stays `SSLReady` after it,
+  so the error can only come from the disposed check and not from the
+  handshake check.
+  """
+  fun name(): String => "net/ssl/SSL.write/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      client.state() is SSLReady,
+      "client should be SSLReady after the handshake")
+
+    client.dispose()
+
+    h.assert_true(
+      client.state() is SSLReady,
+      "dispose() should not change the session state")
+
+    try
+      client.write("data")?
+      h.fail("write() on a disposed session should raise an error")
+    end
+
+    server.dispose()
+
+class \nodoc\ iso _TestSSLALPNSelectedAfterDispose is UnitTest
+  """
+  `alpn_selected` on a disposed session returns `None` rather than the
+  protocol the session negotiated. The session negotiates one before it is
+  disposed, so the `None` afterwards is the disposed check and not the absence
+  of ALPN.
+
+  This test passes with and without the disposed check on OpenSSL, whose
+  `SSL_get0_alpn_selected` checks its own `SSL*` for null. We do not rely on
+  that, and LibreSSL has not been checked, so the disposed check is what keeps
+  the return value from depending on the backend.
+  """
+  fun name(): String => "net/ssl/SSL.alpn_selected/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let auth = FileAuth(h.env.root)
+
+    // The resolver is handed to OpenSSL as callback data, which the Pony GC
+    // cannot see. Hold it here so it outlives the handshake.
+    let resolver = ALPNStandardProtocolResolver(["h2"])
+
+    let sslctx =
+      try
+        recover val
+          SSLContext
+            .> set_authority(FilePath(auth, "assets/cert.pem"))?
+            .> set_cert(
+                FilePath(auth, "assets/cert.pem"),
+                FilePath(auth, "assets/key.pem"))?
+            .> set_client_verify(false)
+            .> set_server_verify(false)
+            .> alpn_set_client_protocols(["h2"])
+            .> alpn_set_resolver(resolver)
+        end
+      else
+        h.fail("ssl context setup failed")
+        return
+      end
+
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.from_context(h, sslctx)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    match client.alpn_selected()
+    | let protocol: ALPNProtocolName =>
+      h.assert_eq[String]("h2", protocol)
+    | None =>
+      h.fail("the client did not negotiate an ALPN protocol")
+    end
+
+    client.dispose()
+
+    h.assert_true(
+      client.alpn_selected() is None,
+      "alpn_selected() on a disposed session should return None")
+
+    server.dispose()
 
 class \nodoc\ iso _TestALPNProtocolListRoundTrip is Property1[Array[String]]
   fun name(): String =>

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -1116,8 +1116,8 @@ class \nodoc\ iso _TestSSLHandshakeInMemory is UnitTest
 class \nodoc\ iso _TestSSLDisposeBeforeHandshake is UnitTest
   """
   A session disposed before its handshake finishes is inert too, and `state`
-  keeps returning `SSLHandshake`. This is the case from issue #66: a fresh
-  client session, disposed, then read.
+  reports `SSLDisposed` rather than the `SSLHandshake` it was in. This is the
+  case from issue #66: a fresh client session, disposed, then read.
 
   A fresh client session has a ClientHello waiting to go out, so `can_send`
   returning `false` after the dispose is the disposed check and not an empty
@@ -1144,8 +1144,8 @@ class \nodoc\ iso _TestSSLDisposeBeforeHandshake is UnitTest
     client.dispose()
 
     h.assert_true(
-      client.state() is SSLHandshake,
-      "dispose() should not change the session state")
+      client.state() is SSLDisposed,
+      "dispose() from SSLHandshake should leave the session SSLDisposed")
     h.assert_true(
       client.read() is None,
       "read() on a disposed session should return None")
@@ -1370,12 +1370,12 @@ class \nodoc\ iso _TestSSLSendAfterDispose is UnitTest
 
 class \nodoc\ iso _TestSSLWriteAfterDispose is UnitTest
   """
-  `write` on a disposed session raises an error. Before the fix it returned as
-  though the data had been written, and nothing was written.
+  `write` on a disposed session does nothing and does not raise. Being disposed
+  is not an error, and `write`'s only error means the handshake is not
+  complete, which is not what happened here.
 
-  The session is `SSLReady` before the dispose and stays `SSLReady` after it,
-  so the error can only come from the disposed check and not from the
-  handshake check.
+  The session reaches `SSLReady` first, so the dispose is the only reason
+  `write` could have to stop, and `state` reports `SSLDisposed` afterwards.
   """
   fun name(): String => "net/ssl/SSL.write/after_dispose"
 
@@ -1395,13 +1395,18 @@ class \nodoc\ iso _TestSSLWriteAfterDispose is UnitTest
     client.dispose()
 
     h.assert_true(
-      client.state() is SSLReady,
-      "dispose() should not change the session state")
+      client.state() is SSLDisposed,
+      "dispose() from SSLReady should leave the session SSLDisposed")
 
     try
       client.write("data")?
-      h.fail("write() on a disposed session should raise an error")
+    else
+      h.fail("write() on a disposed session should not raise an error")
     end
+
+    h.assert_false(
+      client.can_send(),
+      "write() on a disposed session should not queue anything to send")
 
     server.dispose()
 

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -31,11 +31,40 @@ primitive _SSL
 primitive _BIO
 
 primitive SSLHandshake
-primitive SSLAuthFail
-primitive SSLReady
-primitive SSLError
+  """
+  The session is still handshaking.
+  """
 
-type SSLState is (SSLHandshake | SSLAuthFail | SSLReady | SSLError)
+primitive SSLAuthFail
+  """
+  The peer's certificate could not be verified.
+  """
+
+primitive SSLReady
+  """
+  The handshake is complete. Application data can be sent and received.
+  """
+
+primitive SSLError
+  """
+  The session failed.
+  """
+
+primitive SSLDisposed
+  """
+  The session has been disposed. Nothing more comes out of it: `read` returns
+  `None`, `can_send` returns `false`, `alpn_selected` returns `None`, `receive`
+  and `write` do nothing, and `send` raises an error.
+  """
+
+type SSLState is
+  (SSLHandshake | SSLAuthFail | SSLReady | SSLError | SSLDisposed)
+  """
+  The state of an SSL session. A session starts in `SSLHandshake` and reaches
+  `SSLReady`, `SSLAuthFail`, or `SSLError` from there. A ready session can
+  still fail into `SSLError` later. Disposing a session puts it in
+  `SSLDisposed` from any state, and it stays there.
+  """
 
 class SSL
   """
@@ -45,6 +74,8 @@ class SSL
   let _hostname: String
   let _verify: Bool
   var _ssl: Pointer[_SSL]
+  // `dispose` frees these two along with `_ssl` and nulls all three. Check
+  // `_ssl.is_null()` before touching either of them.
   var _input: Pointer[_BIO] tag
   var _output: Pointer[_BIO] tag
   var _state: SSLState = SSLHandshake
@@ -99,7 +130,7 @@ class SSL
     Get the protocol identifier negotiated via ALPN. Returns None if the
     session has been disposed.
     """
-    if _is_disposed() then return None end
+    if _ssl.is_null() then return None end
 
     var ptr: Pointer[U8] iso = recover Pointer[U8] end
     var len = U32(0)
@@ -116,8 +147,7 @@ class SSL
 
   fun state(): SSLState =>
     """
-    Returns the SSL session state. A disposed session keeps returning the state
-    it was in when it was disposed; see `dispose`.
+    Returns the SSL session state.
     """
     _state
 
@@ -128,7 +158,7 @@ class SSL
     (or less than `expect` bytes) is available, this returns None. A disposed
     session returns None.
     """
-    if _is_disposed() then return None end
+    if _ssl.is_null() then return None end
 
     let offset = _read_buf.size()
 
@@ -206,10 +236,12 @@ class SSL
 
   fun ref write(data: ByteSeq) ? =>
     """
-    When application data is sent, add it to the SSL session. Raises an error
-    if the handshake is not complete or the session has been disposed.
+    When application data is sent, add it to the SSL session. Does nothing if
+    the session has been disposed. Raises an error if the handshake is not
+    complete.
     """
-    if _is_disposed() or (_state isnt SSLReady) then error end
+    if _ssl.is_null() then return end
+    if _state isnt SSLReady then error end
 
     if data.size() > 0 then
       @SSL_write(_ssl, data.cpointer(), data.size().u32())
@@ -220,7 +252,7 @@ class SSL
     When data is received, add it to the SSL session. Does nothing if the
     session has been disposed.
     """
-    if _is_disposed() then return end
+    if _ssl.is_null() then return end
 
     @BIO_write(_input, data.cpointer(), data.size().u32())
 
@@ -242,16 +274,16 @@ class SSL
     Returns true if there are encrypted bytes to be passed to the destination.
     Returns false if the session has been disposed.
     """
-    if _is_disposed() then return false end
+    if _ssl.is_null() then return false end
 
     @BIO_ctrl_pending(_output) > 0
 
   fun ref send(): Array[U8] iso^ ? =>
     """
     Returns encrypted bytes to be passed to the destination. Raises an error
-    if no data is available or the session has been disposed.
+    if no data is available. A disposed session has no data.
     """
-    if _is_disposed() then error end
+    if _ssl.is_null() then error end
 
     let len = @BIO_ctrl_pending(_output)
     if len == 0 then error end
@@ -262,22 +294,22 @@ class SSL
 
   fun ref dispose() =>
     """
-    Dispose of the session.
-
-    Afterwards, `read` returns `None`, `receive` does nothing, `can_send`
-    returns `false`, `alpn_selected` returns `None`, and `write` and `send`
-    raise an error. `state` keeps returning the state the session was in when
-    it was disposed.
+    Dispose of the session. `state` returns `SSLDisposed` afterwards, whatever
+    state the session was in before.
     """
     if not _ssl.is_null() then
       // `_create` handed both BIOs to the session with `SSL_set_bio`, so
-      // `SSL_free` frees them along with the session. Null all three fields
-      // rather than leave two of them pointing at freed memory.
+      // `SSL_free` frees all three. Nulling `_ssl` is what keeps the other
+      // methods away from the freed BIOs, because they all check it first.
+      // Null the BIOs as well, so a method that ever forgets that check finds
+      // a null pointer instead of freed memory.
       @SSL_free(_ssl)
       _ssl = Pointer[_SSL]
       _input = Pointer[_BIO]
       _output = Pointer[_BIO]
     end
+
+    _state = SSLDisposed
 
   fun _final() =>
     """
@@ -286,13 +318,6 @@ class SSL
     if not _ssl.is_null() then
       @SSL_free(_ssl)
     end
-
-  fun _is_disposed(): Bool =>
-    """
-    True once `dispose` has run. `dispose` nulls `_ssl`, `_input` and `_output`
-    together, so a null `_ssl` means both BIOs have been freed as well.
-    """
-    _ssl.is_null()
 
   fun ref _verify_hostname() =>
     """

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -96,8 +96,11 @@ class SSL
 
   fun box alpn_selected(): (ALPNProtocolName | None) =>
     """
-    Get the protocol identifier negotiated via ALPN
+    Get the protocol identifier negotiated via ALPN. Returns None if the
+    session has been disposed.
     """
+    if _is_disposed() then return None end
+
     var ptr: Pointer[U8] iso = recover Pointer[U8] end
     var len = U32(0)
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
@@ -113,7 +116,8 @@ class SSL
 
   fun state(): SSLState =>
     """
-    Returns the SSL session state.
+    Returns the SSL session state. A disposed session keeps returning the state
+    it was in when it was disposed; see `dispose`.
     """
     _state
 
@@ -121,8 +125,11 @@ class SSL
     """
     Returns unencrypted bytes to be passed to the application. If `expect` is
     non-zero, the number of bytes returned will be exactly `expect`. If no data
-    (or less than `expect` bytes) is available, this returns None.
+    (or less than `expect` bytes) is available, this returns None. A disposed
+    session returns None.
     """
+    if _is_disposed() then return None end
+
     let offset = _read_buf.size()
 
     var len = if expect > 0 then
@@ -200,9 +207,9 @@ class SSL
   fun ref write(data: ByteSeq) ? =>
     """
     When application data is sent, add it to the SSL session. Raises an error
-    if the handshake is not complete.
+    if the handshake is not complete or the session has been disposed.
     """
-    if _state isnt SSLReady then error end
+    if _is_disposed() or (_state isnt SSLReady) then error end
 
     if data.size() > 0 then
       @SSL_write(_ssl, data.cpointer(), data.size().u32())
@@ -210,8 +217,11 @@ class SSL
 
   fun ref receive(data: ByteSeq) =>
     """
-    When data is received, add it to the SSL session.
+    When data is received, add it to the SSL session. Does nothing if the
+    session has been disposed.
     """
+    if _is_disposed() then return end
+
     @BIO_write(_input, data.cpointer(), data.size().u32())
 
     if _state is SSLHandshake then
@@ -230,14 +240,19 @@ class SSL
   fun ref can_send(): Bool =>
     """
     Returns true if there are encrypted bytes to be passed to the destination.
+    Returns false if the session has been disposed.
     """
+    if _is_disposed() then return false end
+
     @BIO_ctrl_pending(_output) > 0
 
   fun ref send(): Array[U8] iso^ ? =>
     """
     Returns encrypted bytes to be passed to the destination. Raises an error
-    if no data is available.
+    if no data is available or the session has been disposed.
     """
+    if _is_disposed() then error end
+
     let len = @BIO_ctrl_pending(_output)
     if len == 0 then error end
 
@@ -248,10 +263,20 @@ class SSL
   fun ref dispose() =>
     """
     Dispose of the session.
+
+    Afterwards, `read` returns `None`, `receive` does nothing, `can_send`
+    returns `false`, `alpn_selected` returns `None`, and `write` and `send`
+    raise an error. `state` keeps returning the state the session was in when
+    it was disposed.
     """
     if not _ssl.is_null() then
+      // `_create` handed both BIOs to the session with `SSL_set_bio`, so
+      // `SSL_free` frees them along with the session. Null all three fields
+      // rather than leave two of them pointing at freed memory.
       @SSL_free(_ssl)
       _ssl = Pointer[_SSL]
+      _input = Pointer[_BIO]
+      _output = Pointer[_BIO]
     end
 
   fun _final() =>
@@ -261,6 +286,13 @@ class SSL
     if not _ssl.is_null() then
       @SSL_free(_ssl)
     end
+
+  fun _is_disposed(): Bool =>
+    """
+    True once `dispose` has run. `dispose` nulls `_ssl`, `_input` and `_output`
+    together, so a null `_ssl` means both BIOs have been freed as well.
+    """
+    _ssl.is_null()
 
   fun ref _verify_hostname() =>
     """

--- a/ssl/net/ssl_connection.pony
+++ b/ssl/net/ssl_connection.pony
@@ -168,6 +168,11 @@ class SSLConnection is TCPConnectionNotify
       end
 
       return true
+    | SSLDisposed =>
+      // `closed` disposes the session after its last `_poll`, so this arm is
+      // not reached while the connection is open. Once the session is gone
+      // there is nothing to read and nothing to send.
+      return false
     end
 
     var continue_reading: Bool = true


### PR DESCRIPTION
`SSL.dispose()` freed the session with `SSL_free`, which also frees the two BIOs that `SSL_set_bio` gave the session. `dispose` nulled only `_ssl` and left `_input` and `_output` pointing at freed memory. Every method other than `state`, `dispose`, and `_final` then handed a null or freed pointer to OpenSSL. `read`, `receive`, `can_send`, and `send` crashed. `write` and `alpn_selected` did not, only because OpenSSL null-checks the session pointer.

`dispose` now nulls all three pointers, and a disposed session no longer passes any of them to OpenSSL. It is inert: `read` returns `None`, `receive` and `write` do nothing, `can_send` returns `false`, `alpn_selected` returns `None`, and `send` raises the error it always raised when there was nothing to send. `read` also stops handing back decrypted bytes left over from an incomplete `expect` frame, which was the one thing it did after a dispose without crashing.

`SSLState` gains a fifth member, `SSLDisposed`, and `dispose` puts the session in it from any state. Before, `state()` reported `SSLReady` for a session whose memory had been freed. This is the breaking half of the PR: any `match \exhaustive\` over `SSLState` needs a new branch, and code that read `state()` after a dispose to recover the state the session was in before can no longer do that. `SSLConnection` handles the new state, so anything built on it needs no change.

`write` on a disposed session does nothing rather than raising. Being disposed is not an error, and `write`'s one error means the handshake is not complete.

The reason this matters beyond the crash: an application holding an `SSL ref` alias across a `dispose()` that runs inside a callback is exactly what lori does (ponylang/lori#310), and no type stops that alias from being used afterward. A TCP loopback probe of that path segfaults against `main` and runs clean against this branch.

Closes #66
