### PR TITLE
Fix crashes when using a disposed SSL context

### DIFF
--- a/.release-notes/fix-disposed-ssl-context-crashes.md
+++ b/.release-notes/fix-disposed-ssl-context-crashes.md
@@ -1,0 +1,7 @@
+## Fix crashes when using a disposed SSL context
+
+Calling a method on an `SSLContext` after `dispose()` could crash the program. `alpn_set_resolver` and `alpn_set_client_protocols` crashed against every SSL backend. `set_min_proto_version`, `set_max_proto_version`, `get_min_proto_version` and `get_max_proto_version` crashed against LibreSSL. `set_authority(None, None)`, which loads the system root certificates, crashed on Windows.
+
+A disposed context is now inert, and every backend treats it the same. `alpn_set_resolver` and `alpn_set_client_protocols` return `false`. `set_min_proto_version` and `set_max_proto_version` raise an error, and `get_min_proto_version` and `get_max_proto_version` return `SslAutoVersion`. `set_authority` raises an error whether or not you hand it a file.
+
+`client` and `server` on a disposed context raised an error, which is what they should do, and could then crash the program the next time the garbage collector ran. The crash landed far from the call that caused it. That no longer happens.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,12 @@ LibreSSL's API is mostly OpenSSL 1.1.x compatible, with five differences that re
 4. **`SSL_get_peer_certificate`** — LibreSSL uses the pre-3.0.x name (not `SSL_get1_peer_certificate`)
 5. **`OPENSSL_INIT_new`/`OPENSSL_INIT_free`** — not available in LibreSSL. Init uses `OPENSSL_init_ssl` directly with no settings object
 
+## Dispose Conventions
+
+`dispose()` frees the OpenSSL handle and nulls the pointer field, so any later call would hand OpenSSL a null. Most of the C functions dereference it without checking, and the ones that don't vary by backend — `SSL_CTX_ctrl` returns 0 for a null context on OpenSSL but dereferences it on LibreSSL. Check `is_null()` before calling into OpenSSL, and don't count on a backend being forgiving.
+
+Pony registers a `_final` when it allocates the object, not when the constructor returns, so `_final` runs even on an object whose constructor raised. A pointer field that `_final` frees needs a null default at its declaration, or it frees whatever was left in the recycled heap slot.
+
 ## ifdef Conventions
 
 Version-specific code uses two patterns:

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -22,6 +22,21 @@ actor \nodoc\ Main is TestList
     test(_TestSSLSendAfterDispose)
     test(_TestSSLWriteAfterDispose)
     test(_TestSSLALPNSelectedAfterDispose)
+    test(_TestSSLContextDisposeTwice)
+    test(_TestSSLContextALPNSetResolverAfterDispose)
+    test(_TestSSLContextALPNSetClientProtocolsAfterDispose)
+    test(_TestSSLContextSetMinProtoVersionAfterDispose)
+    test(_TestSSLContextSetMaxProtoVersionAfterDispose)
+    test(_TestSSLContextGetMinProtoVersionAfterDispose)
+    test(_TestSSLContextGetMaxProtoVersionAfterDispose)
+    test(_TestSSLContextSetAuthorityRootCertsAfterDispose)
+    test(_TestSSLContextSetAuthorityAfterDispose)
+    test(_TestSSLContextSetCertAfterDispose)
+    test(_TestSSLContextSetCiphersAfterDispose)
+    test(_TestSSLContextSetVerifyDepthAfterDispose)
+    test(_TestSSLContextAllowTlsAfterDispose)
+    test(_TestSSLContextClientAfterDispose)
+    test(_TestSSLContextServerAfterDispose)
     test(_TestTCPSSLWritev)
     test(_TestTCPSSLExpect)
     test(_TestTCPSSLMute)
@@ -1471,6 +1486,419 @@ class \nodoc\ iso _TestSSLALPNSelectedAfterDispose is UnitTest
       "alpn_selected() on a disposed session should return None")
 
     server.dispose()
+
+class \nodoc\ iso _TestSSLContextDisposeTwice is UnitTest
+  """
+  Disposing a context twice does not free it twice, and the context is still
+  inert afterwards.
+
+  `dispose` nulling `_ctx` is what makes the second call safe, and losing that
+  is what this test would catch. The `_ctx.is_null()` check in `dispose` is belt
+  and braces, because `SSL_CTX_free` ignores a null pointer.
+  """
+  fun name(): String => "net/ssl/SSLContext.dispose/twice"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    ctx.dispose()
+    ctx.dispose()
+
+    // A live context accepts this protocol list, so a `false` here is the
+    // context still being disposed and not a list it rejected.
+    h.assert_false(
+      ctx.alpn_set_client_protocols(["h2"]),
+      "a disposed context should still be inert after a second dispose()")
+
+class \nodoc\ iso _TestSSLContextALPNSetResolverAfterDispose is UnitTest
+  """
+  `alpn_set_resolver` on a disposed context returns `false` rather than passing
+  a null `SSL_CTX*` to `SSL_CTX_set_alpn_select_cb`, which dereferences it on
+  every backend.
+
+  The live context returns `true`, so the `false` afterwards is the disposed
+  check and not a resolver the context rejected.
+  """
+  fun name(): String => "net/ssl/SSLContext.alpn_set_resolver/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    // The resolver is handed to OpenSSL as callback data, which the Pony GC
+    // cannot see. Hold it here so it outlives the context.
+    let resolver = ALPNStandardProtocolResolver(["h2"])
+    let ctx = SSLContext
+
+    h.assert_true(
+      ctx.alpn_set_resolver(resolver),
+      "alpn_set_resolver() on a live context should return true")
+
+    ctx.dispose()
+
+    h.assert_false(
+      ctx.alpn_set_resolver(resolver),
+      "alpn_set_resolver() on a disposed context should return false")
+
+class \nodoc\ iso _TestSSLContextALPNSetClientProtocolsAfterDispose is UnitTest
+  """
+  `alpn_set_client_protocols` on a disposed context returns `false` rather than
+  passing a null `SSL_CTX*` to `SSL_CTX_set_alpn_protos`, which dereferences it
+  on every backend.
+
+  The protocol list is valid and the live context accepts it, so the `false`
+  afterwards is the disposed check and not the encoding failure that also
+  returns `false`.
+  """
+  fun name(): String =>
+    "net/ssl/SSLContext.alpn_set_client_protocols/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    h.assert_true(
+      ctx.alpn_set_client_protocols(["h2"]),
+      "alpn_set_client_protocols() on a live context should return true")
+
+    ctx.dispose()
+
+    h.assert_false(
+      ctx.alpn_set_client_protocols(["h2"]),
+      "alpn_set_client_protocols() on a disposed context should return false")
+
+class \nodoc\ iso _TestSSLContextSetMinProtoVersionAfterDispose is UnitTest
+  """
+  `set_min_proto_version` on a disposed context raises an error rather than
+  passing a null `SSL_CTX*` to `SSL_CTX_ctrl`.
+
+  This test passes with and without the disposed check on OpenSSL, whose
+  `SSL_CTX_ctrl` returns 0 for a null context, which this method already turns
+  into an error. LibreSSL's `SSL_CTX_ctrl` dereferences the context instead, so
+  LibreSSL is where the check keeps this from being a crash.
+  """
+  fun name(): String => "net/ssl/SSLContext.set_min_proto_version/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    try
+      ctx.set_min_proto_version(Tls1u2Version())?
+    else
+      h.fail("set_min_proto_version() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_min_proto_version(Tls1u2Version())?
+      h.fail("set_min_proto_version() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestSSLContextSetMaxProtoVersionAfterDispose is UnitTest
+  """
+  `set_max_proto_version` on a disposed context raises an error rather than
+  passing a null `SSL_CTX*` to `SSL_CTX_ctrl`.
+
+  Carries the same caveat as
+  `net/ssl/SSLContext.set_min_proto_version/after_dispose`: only LibreSSL
+  crashes without the check.
+  """
+  fun name(): String => "net/ssl/SSLContext.set_max_proto_version/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    try
+      ctx.set_max_proto_version(Tls1u3Version())?
+    else
+      h.fail("set_max_proto_version() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_max_proto_version(Tls1u3Version())?
+      h.fail("set_max_proto_version() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestSSLContextGetMinProtoVersionAfterDispose is UnitTest
+  """
+  `get_min_proto_version` on a disposed context returns `SslAutoVersion` rather
+  than passing a null `SSL_CTX*` to `SSL_CTX_ctrl`.
+
+  `create` sets the minimum to `Tls1u2Version`, so the `SslAutoVersion`
+  afterwards is not the value a live context would have returned.
+
+  This test passes with and without the disposed check on OpenSSL, whose
+  `SSL_CTX_ctrl` returns 0 for a null context. LibreSSL's dereferences it, so
+  LibreSSL is where the check keeps this from being a crash.
+  """
+  fun name(): String => "net/ssl/SSLContext.get_min_proto_version/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    h.assert_eq[ILong](
+      Tls1u2Version().ilong(),
+      ctx.get_min_proto_version(),
+      "create() should have set the minimum protocol version to TLS v1.2")
+
+    ctx.dispose()
+
+    h.assert_eq[ILong](
+      SslAutoVersion().ilong(),
+      ctx.get_min_proto_version(),
+      "get_min_proto_version() on a disposed context should return "
+        + "SslAutoVersion")
+
+class \nodoc\ iso _TestSSLContextGetMaxProtoVersionAfterDispose is UnitTest
+  """
+  `get_max_proto_version` on a disposed context returns `SslAutoVersion` rather
+  than passing a null `SSL_CTX*` to `SSL_CTX_ctrl`.
+
+  `create` leaves the maximum at `SslAutoVersion`, so this test sets it to
+  `Tls1u3Version` first. Without that, the assertion after the dispose would
+  hold for a live context too.
+
+  Carries the same caveat as
+  `net/ssl/SSLContext.get_min_proto_version/after_dispose`: only LibreSSL
+  crashes without the check.
+  """
+  fun name(): String => "net/ssl/SSLContext.get_max_proto_version/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    try
+      ctx.set_max_proto_version(Tls1u3Version())?
+    else
+      h.fail("set_max_proto_version() on a live context should not raise")
+      return
+    end
+
+    h.assert_eq[ILong](
+      Tls1u3Version().ilong(),
+      ctx.get_max_proto_version(),
+      "the maximum protocol version should read back as TLS v1.3")
+
+    ctx.dispose()
+
+    h.assert_eq[ILong](
+      SslAutoVersion().ilong(),
+      ctx.get_max_proto_version(),
+      "get_max_proto_version() on a disposed context should return "
+        + "SslAutoVersion")
+
+class \nodoc\ iso _TestSSLContextSetAuthorityRootCertsAfterDispose is UnitTest
+  """
+  `set_authority(None, None)` on a disposed context raises an error rather than
+  loading the system root certificates into a null `SSL_CTX*`.
+
+  On Posix this raises whether or not the context is disposed; there are no
+  system root certificates to load and the method has always raised. On Windows
+  a live context loads them, and a disposed one used to reach
+  `SSL_CTX_set_cert_store` with a null context and crash. Windows CI is where
+  this test earns its keep.
+  """
+  fun name(): String =>
+    "net/ssl/SSLContext.set_authority/root_certs_after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    ctx.dispose()
+
+    try
+      ctx.set_authority(None, None)?
+      h.fail("set_authority(None, None) on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestSSLContextSetAuthorityAfterDispose is UnitTest
+  """
+  `set_authority` on a disposed context raises an error. This locks in a guard
+  the disposed context already had.
+  """
+  fun name(): String => "net/ssl/SSLContext.set_authority/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let auth = FileAuth(h.env.root)
+    let ctx = SSLContext
+
+    try
+      ctx.set_authority(FilePath(auth, "assets/cert.pem"))?
+    else
+      h.fail("set_authority() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_authority(FilePath(auth, "assets/cert.pem"))?
+      h.fail("set_authority() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestSSLContextSetCertAfterDispose is UnitTest
+  """
+  `set_cert` on a disposed context raises an error. This locks in a guard the
+  disposed context already had.
+  """
+  fun name(): String => "net/ssl/SSLContext.set_cert/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let auth = FileAuth(h.env.root)
+    let cert = FilePath(auth, "assets/cert.pem")
+    let key = FilePath(auth, "assets/key.pem")
+    let ctx = SSLContext
+
+    try
+      ctx.set_cert(cert, key)?
+    else
+      h.fail("set_cert() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_cert(cert, key)?
+      h.fail("set_cert() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestSSLContextSetCiphersAfterDispose is UnitTest
+  """
+  `set_ciphers` on a disposed context raises an error. This locks in a guard the
+  disposed context already had.
+
+  The cipher list is one a live context accepts, so the error after the dispose
+  is the disposed check and not the invalid-cipher-list error.
+  """
+  fun name(): String => "net/ssl/SSLContext.set_ciphers/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    try
+      ctx.set_ciphers("HIGH")?
+    else
+      h.fail("set_ciphers(\"HIGH\") on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_ciphers("HIGH")?
+      h.fail("set_ciphers() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestSSLContextSetVerifyDepthAfterDispose is UnitTest
+  """
+  `set_verify_depth` on a disposed context does nothing. This locks in a guard
+  the disposed context already had; without it, `SSL_CTX_set_verify_depth`
+  dereferences the null context on every backend.
+
+  There is nothing to observe beyond the call returning, so the context is
+  checked for inertness afterwards.
+  """
+  fun name(): String => "net/ssl/SSLContext.set_verify_depth/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    ctx.dispose()
+    ctx.set_verify_depth(4)
+
+    // A live context accepts this protocol list, so a `false` here is the
+    // context still being disposed and not a list it rejected.
+    h.assert_false(
+      ctx.alpn_set_client_protocols(["h2"]),
+      "the context should still be disposed")
+
+class \nodoc\ iso _TestSSLContextAllowTlsAfterDispose is UnitTest
+  """
+  `allow_tls_v1`, `allow_tls_v1_1` and `allow_tls_v1_2` on a disposed context do
+  nothing. This locks in guards the disposed context already had.
+
+  Unlike the protocol version methods, these catch a missing guard on every
+  backend. They reach `SSL_CTX_set_options` and `SSL_CTX_clear_options` on
+  OpenSSL and `SSL_CTX_ctrl` on LibreSSL, and all three dereference the null
+  context.
+
+  Both states of each are exercised, because one clears an option and the other
+  sets it, and they reach different C functions on OpenSSL.
+  """
+  fun name(): String => "net/ssl/SSLContext.allow_tls/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    ctx.dispose()
+
+    ctx.allow_tls_v1(true)
+    ctx.allow_tls_v1(false)
+    ctx.allow_tls_v1_1(true)
+    ctx.allow_tls_v1_1(false)
+    ctx.allow_tls_v1_2(true)
+    ctx.allow_tls_v1_2(false)
+
+    // A live context accepts this protocol list, so a `false` here is the
+    // context still being disposed and not a list it rejected.
+    h.assert_false(
+      ctx.alpn_set_client_protocols(["h2"]),
+      "the context should still be disposed")
+
+class \nodoc\ iso _TestSSLContextClientAfterDispose is UnitTest
+  """
+  `client` on a disposed context raises an error rather than handing a null
+  context to `SSL_new`.
+
+  Two things make it raise and the test cannot tell them apart: `SSL._create`
+  checks the context before it calls `SSL_new`, and `SSL_new` returns null for a
+  null context on every backend, which `SSL._create` raises on as well.
+  """
+  fun name(): String => "net/ssl/SSLContext.client/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    try
+      let session = ctx.client()?
+      session.dispose()
+    else
+      h.fail("client() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      let session = ctx.client()?
+      session.dispose()
+      h.fail("client() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestSSLContextServerAfterDispose is UnitTest
+  """
+  `server` on a disposed context raises an error rather than handing a null
+  context to `SSL_new`.
+
+  Carries the same caveat as `net/ssl/SSLContext.client/after_dispose`: the
+  context check in `SSL._create` and `SSL_new` returning null both produce the
+  error, and the test cannot tell them apart.
+  """
+  fun name(): String => "net/ssl/SSLContext.server/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = SSLContext
+
+    try
+      let session = ctx.server()?
+      session.dispose()
+    else
+      h.fail("server() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      let session = ctx.server()?
+      session.dispose()
+      h.fail("server() on a disposed context should raise")
+    end
 
 class \nodoc\ iso _TestALPNProtocolListRoundTrip is Property1[Array[String]]
   fun name(): String =>

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -10,6 +10,7 @@ use @SSL_free[None](ssl: Pointer[_SSL] tag)
 use @SSL_set_verify[None](ssl: Pointer[_SSL], mode: I32, cb: Pointer[U8])
 use @BIO_s_mem[Pointer[U8]]()
 use @BIO_new[Pointer[_BIO]](typ: Pointer[U8])
+use @BIO_free[I32](bio: Pointer[_BIO] tag)
 use @SSL_set_bio[None](ssl: Pointer[_SSL], rbio: Pointer[_BIO] tag, wbio: Pointer[_BIO] tag)
 use @SSL_set_accept_state[None](ssl: Pointer[_SSL])
 use @SSL_set_connect_state[None](ssl: Pointer[_SSL])
@@ -73,11 +74,9 @@ class SSL
   """
   let _hostname: String
   let _verify: Bool
-  var _ssl: Pointer[_SSL]
-  // `dispose` frees these two along with `_ssl` and nulls all three. Check
-  // `_ssl.is_null()` before touching either of them.
-  var _input: Pointer[_BIO] tag
-  var _output: Pointer[_BIO] tag
+  var _ssl: Pointer[_SSL] = Pointer[_SSL]
+  var _input: Pointer[_BIO] tag = Pointer[_BIO]
+  var _output: Pointer[_BIO] tag = Pointer[_BIO]
   var _state: SSLState = SSLHandshake
   var _read_buf: Array[U8] iso = []
 
@@ -105,7 +104,13 @@ class SSL
     if _input.is_null() then error end
 
     _output = @BIO_new(@BIO_s_mem())
-    if _output.is_null() then error end
+    if _output.is_null() then
+      // `SSL_set_bio` below is what hands the BIOs to the session, and it has
+      // not run, so the `SSL_free` in `_final` will not free `_input`.
+      @BIO_free(_input)
+      _input = Pointer[_BIO]
+      error
+    end
 
     @SSL_set_bio(_ssl, _input, _output)
 

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -71,7 +71,8 @@ class val SSLContext
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       _ctx = @SSL_CTX_new(@TLS_method())
 
-      // Allow only newer ciphers.
+      // Allow only newer ciphers. These raise only if `SSL_CTX_new` failed,
+      // and a null context can never make a session, so the swallow is safe.
       try
         set_min_proto_version(Tls1u2Version())?
         set_max_proto_version(SslAutoVersion())?
@@ -101,7 +102,8 @@ class val SSLContext
   fun client(hostname: String = ""): SSL iso^ ? =>
     """
     Create a client-side SSL session. If a hostname is supplied, the server
-    side certificate must be valid for that hostname.
+    side certificate must be valid for that hostname. Raises an error if the
+    context has been disposed.
     """
     let ctx = _ctx
     let verify = _client_verify
@@ -109,7 +111,8 @@ class val SSLContext
 
   fun server(): SSL iso^ ? =>
     """
-    Create a server-side SSL session.
+    Create a server-side SSL session. Raises an error if the context has been
+    disposed.
     """
     let ctx = _ctx
     let verify = _server_verify
@@ -118,11 +121,13 @@ class val SSLContext
   fun ref set_cert(cert: FilePath, key: FilePath) ? =>
     """
     The cert file is a PEM certificate chain. The key file is a private key.
-    Servers must set this. For clients, it is optional.
+    Servers must set this. For clients, it is optional. Raises an error if the
+    context has been disposed.
     """
+    if _ctx.is_null() then error end
+
     if
-      _ctx.is_null()
-        or (cert.path.size() == 0)
+      (cert.path.size() == 0)
         or (key.path.size() == 0)
         or (0 == @SSL_CTX_use_certificate_chain_file(
           _ctx, cert.path.cstring()))
@@ -142,11 +147,13 @@ class val SSLContext
     Use a PEM file and/or a directory of PEM files to specify certificate
     authorities. Clients must set this. For servers, it is optional. Use None
     to indicate no file or no path. Raises an error if these verify locations
-    aren't valid.
+    aren't valid, or if the context has been disposed.
 
     If both `file` and `path` are `None`, on Windows this method loads the
     system root certificates. On Posix it raises an error.
     """
+    if _ctx.is_null() then error end
+
     if (file is None) and (path is None) then
       ifdef windows then
         _load_windows_root_certs()?
@@ -161,8 +168,7 @@ class val SSLContext
       let p = if ps.size() > 0 then ps.cstring() else Pointer[U8] end
 
       if
-        _ctx.is_null()
-          or (f.is_null() and p.is_null())
+        (f.is_null() and p.is_null())
           or (0 == @SSL_CTX_load_verify_locations(_ctx, f, p))
       then
         error
@@ -207,12 +213,11 @@ class val SSLContext
   fun ref set_ciphers(ciphers: String) ? =>
     """
     Set the accepted ciphers. This replaces the existing list. Raises an error
-    if the cipher list is invalid.
+    if the cipher list is invalid, or if the context has been disposed.
     """
-    if
-      _ctx.is_null()
-        or (0 == @SSL_CTX_set_cipher_list(_ctx, ciphers.cstring()))
-    then
+    if _ctx.is_null() then error end
+
+    if 0 == @SSL_CTX_set_cipher_list(_ctx, ciphers.cstring()) then
       error
     end
 
@@ -230,7 +235,8 @@ class val SSLContext
 
   fun ref set_verify_depth(depth: U32) =>
     """
-    Set the verify depth. Defaults to 6.
+    Set the verify depth. Defaults to 6. Does nothing if the context has been
+    disposed.
     """
     if not _ctx.is_null() then
       @SSL_CTX_set_verify_depth(_ctx, depth)
@@ -239,12 +245,15 @@ class val SSLContext
   fun ref set_min_proto_version(version: ULong) ? =>
     """
     Set minimum protocol version. Set to SslAutoVersion, 0,
-    to automatically manage lowest version.
+    to automatically manage lowest version. Raises an error if the context has
+    been disposed.
 
     Supported versions: Ssl3Version, Tls1Version, Tls1u1Version,
                         Tls1u2Version, Tls1u3Version, Dtls1Version,
                         Dtls1u2Version
     """
+    if _ctx.is_null() then error end
+
     let result =
       @SSL_CTX_ctrl(_ctx, _SslCtrlSetMinProtoVersion(), version, Pointer[None])
     if result == 0 then
@@ -254,23 +263,29 @@ class val SSLContext
   fun ref get_min_proto_version(): ILong =>
     """
     Get minimum protocol version. Returns SslAutoVersion, 0,
-    when automatically managing lowest version.
+    when automatically managing lowest version. A disposed context returns
+    SslAutoVersion.
 
     Supported versions: Ssl3Version, Tls1Version, Tls1u1Version,
                         Tls1u2Version, Tls1u3Version, Dtls1Version,
                         Dtls1u2Version
     """
+    if _ctx.is_null() then return SslAutoVersion().ilong() end
+
     @SSL_CTX_ctrl(_ctx, _SslCtrlGetMinProtoVersion(), 0, Pointer[None])
 
   fun ref set_max_proto_version(version: ULong) ? =>
     """
     Set maximum protocol version. Set to SslAutoVersion, 0,
-    to automatically manage higest version.
+    to automatically manage higest version. Raises an error if the context has
+    been disposed.
 
     Supported versions: Ssl3Version, Tls1Version, Tls1u1Version,
                         Tls1u2Version, Tls1u3Version, Dtls1Version,
                         Dtls1u2Version
     """
+    if _ctx.is_null() then error end
+
     let result =
       @SSL_CTX_ctrl(_ctx, _SslCtrlSetMaxProtoVersion(), version, Pointer[None])
     if result == 0 then
@@ -280,20 +295,25 @@ class val SSLContext
   fun ref get_max_proto_version(): ILong =>
     """
     Get maximum protocol version. Returns SslAutoVersion, 0,
-    when automatically managing highest version.
+    when automatically managing highest version. A disposed context returns
+    SslAutoVersion.
 
     Supported versions: Ssl3Version, Tls1Version, Tls1u1Version,
                         Tls1u2Version, Tls1u3Version, Dtls1Version,
                         Dtls1u2Version
     """
+    if _ctx.is_null() then return SslAutoVersion().ilong() end
+
     @SSL_CTX_ctrl(_ctx, _SslCtrlGetMaxProtoVersion(), 0, Pointer[None])
 
   fun ref alpn_set_resolver(resolver: ALPNProtocolResolver box): Bool =>
     """
     Use `resolver` to choose the protocol to be selected for incomming connections.
 
-    Returns true on success.
+    Returns true on success. Returns false if the context has been disposed.
     """
+    if _ctx.is_null() then return false end
+
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       @SSL_CTX_set_alpn_select_cb(
         _ctx, addressof SSLContext._alpn_select_cb, resolver)
@@ -307,8 +327,10 @@ class val SSLContext
     Configures the SSLContext to advertise the protocol names defined in `protocols` when connecting to a server
     protocol names must have a size of 1 to 255
 
-    Returns true on success.
+    Returns true on success. Returns false if the context has been disposed.
     """
+    if _ctx.is_null() then return false end
+
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       try
         let proto_list = _ALPNProtocolList.from_array(protocols)?
@@ -357,7 +379,8 @@ class val SSLContext
 
   fun ref allow_tls_v1(state: Bool) =>
     """
-    Allow TLS v1. Defaults to false.
+    Allow TLS v1. Defaults to false. Does nothing if the context has been
+    disposed.
     Deprecated: use set_min_proto_version and set_max_proto_version
     """
     if not _ctx.is_null() then
@@ -370,7 +393,8 @@ class val SSLContext
 
   fun ref allow_tls_v1_1(state: Bool) =>
     """
-    Allow TLS v1.1. Defaults to false.
+    Allow TLS v1.1. Defaults to false. Does nothing if the context has been
+    disposed.
     Deprecated: use set_min_proto_version and set_max_proto_version
     """
     if not _ctx.is_null() then
@@ -383,7 +407,8 @@ class val SSLContext
 
   fun ref allow_tls_v1_2(state: Bool) =>
     """
-    Allow TLS v1.2. Defaults to true.
+    Allow TLS v1.2. Defaults to true. Does nothing if the context has been
+    disposed.
     Deprecated: use set_min_proto_version and set_max_proto_version
     """
     if not _ctx.is_null() then
@@ -396,7 +421,10 @@ class val SSLContext
 
   fun ref dispose() =>
     """
-    Free the SSL context.
+    Free the SSL context. A disposed context cannot create a session, and no
+    configuration of it can take effect. Every method that hands the context to
+    OpenSSL says in its own docstring what it does once the context has been
+    disposed.
     """
     if not _ctx.is_null() then
       @SSL_CTX_free(_ctx)


### PR DESCRIPTION
Issue #70 named the two ALPN methods. Probing every SSL library CI builds against turned up five more. `alpn_set_resolver` and `alpn_set_client_protocols` crash against every backend. `set_min_proto_version`, `set_max_proto_version`, `get_min_proto_version` and `get_max_proto_version` crash against LibreSSL, whose `SSL_CTX_ctrl` dereferences the context; OpenSSL's `SSL_CTX_ctrl` returns 0 for a null context on every version we support. `set_authority(None, None)` reaches `SSL_CTX_set_cert_store`, which crashes against every backend, but only the Windows build reaches that branch.

Every method that hands the context to OpenSSL now checks it first. `client` and `server` hand it to `SSL._create`, which does the check. A disposed context behaves the same way on every backend.

Writing the `client` and `server` tests turned up the crash #71 describes, which I hit before I read that issue. Pony registers an object's finalizer when it allocates the object, not when the constructor returns, so `_final` runs on an object whose constructor raised. `SSL._create` raises before it assigns `_ssl`, and `_final` frees `_ssl`, so it freed whatever the recycled heap slot happened to hold. In one run `_ssl` held `0x6c73732f6c73732f`, which is the bytes `/ssl/ssl` from a recycled path string. A repro against pristine `main` sources crashes ten times out of ten. Nothing in the repo called `client` or `server` on a disposed context, so the crash never happened. `_ssl`, `_input` and `_output` now start null, so `_final` has something safe to free wherever `_create` raises.

The second half of #71 is here too. `SSL_set_bio` is what hands the BIOs to the session and it runs after both allocations, so when the second one fails, `_input` is allocated and unowned and nothing frees it. Forcing that allocation to fail and counting the memory BIOs OpenSSL hands out, 100 of them were never freed before and none are now.

Closes #70
Closes #71
