### PR TITLE
Fix allow_tls_v1, allow_tls_v1_1 and allow_tls_v1_2 on 32-bit platforms

### DIFF
--- a/.release-notes/fix-allow-tls-methods-on-32-bit-platforms.md
+++ b/.release-notes/fix-allow-tls-methods-on-32-bit-platforms.md
@@ -1,0 +1,7 @@
+## Fix allow_tls_v1, allow_tls_v1_1 and allow_tls_v1_2 on 32-bit platforms
+
+`SSLContext.allow_tls_v1`, `SSLContext.allow_tls_v1_1` and `SSLContext.allow_tls_v1_2` did not change the protocol version they name, and left the context with TLS options nobody asked for. A call meant to forbid a version left it allowed, a call meant to allow one left it forbidden, and unrelated TLS features were switched on either way.
+
+This affected 32-bit builds using OpenSSL 3.x or 4.x. 64-bit builds, LibreSSL builds, and OpenSSL 1.1.x builds were never affected.
+
+These methods now change only the protocol version they name.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,38 @@ else
 end
 ```
 
+**One symbol whose C signature changes by version** needs two `use` statements, and the second guard must exclude the first. ponyc resolves an FFI call by enumerating every combination of the defines named in the guards, not just the one the build passes, and nothing tells it the `ssl=` defines are mutually exclusive. Overlapping guards give "Multiple possible declarations for FFI call":
+```pony
+use @SSL_CTX_set_options[U64](ctx: Pointer[_SSLContext] tag, opts: U64) if "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_CTX_set_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" and not ("openssl_3.0.x" or "openssl_4.0.x")
+```
+`libressl` appears in neither guard because LibreSSL reaches these options through `SSL_CTX_ctrl` instead — see LibreSSL API Divergences above.
+
+The call site needs an `ifdef` split too. Pony has no implicit numeric conversion, so one call expression cannot satisfy both parameter types.
+
+Adding a new SSL define means adding it to the exclusion list. Forgetting is safe: the enumeration finds the overlap and fails the build on every backend, not just the new one.
+
 Every ifdef chain must end with `compile_error` to catch missing defines at compile time.
+
+## FFI Type Conventions
+
+Declare the Pony type that corresponds to the C type in the header, not one that happens to be the same width on the platforms CI builds:
+
+| C type | Pony type |
+|---|---|
+| `int` / `unsigned int` | `I32` / `U32` |
+| `long` / `unsigned long` | `ILong` / `ULong` |
+| `size_t` | `USize` |
+| `uint64_t` | `U64` |
+| pointer to an opaque C struct | `Pointer[_Name]`, declaring a phantom primitive for it |
+| `void *`, or a pointer only ever passed as null | `Pointer[None]` |
+| pointer to bytes | `Pointer[U8]` |
+
+`ILong`/`ULong` track C's `long`: 32 bits on Windows and on 32-bit targets such as `arm32`, 64 bits on 64-bit Unix-like targets. `USize` tracks `size_t`, which is pointer-width. Neither is a stand-in for `uint64_t`. Reaching for `ULong` because it is 64 bits on the platform in front of you turns a correct call into a wrong one everywhere else — `SSL_CTX_set_options` takes a `uint64_t` in OpenSSL 3.x, and a `ULong` declaration passes 32 bits on every 32-bit build.
+
+A `Pointer[X]`'s element type never reaches the ABI, so `Pointer[USize]` where C says `unsigned int *` cannot break a call that passes null. It breaks the caller who later passes `addressof` a real `USize`: C writes four of the eight bytes and the rest keep whatever was in the slot, so the caller reads a garbage value.
+
+Public Pony signatures do not have to match the C types. Convert at the FFI call instead — `SSLContext.set_verify_depth` takes a `U32` and passes `depth.i32()`. Where the public type admits values the C type cannot hold, converting silently wraps: a depth above `2^31` arrives as a negative `int`. Validate at the public boundary or say so in the docstring; do not let the conversion be the whole answer.
 
 ## Key Files
 

--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -4,9 +4,9 @@ use "lib:crypto"
 use "lib:bcrypt" if windows
 
 use @EVP_MD_CTX_new[Pointer[_EVPCTX]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
-use @EVP_DigestInit_ex[I32](ctx: Pointer[_EVPCTX] tag, t: Pointer[_EVPMD], impl: USize)
+use @EVP_DigestInit_ex[I32](ctx: Pointer[_EVPCTX] tag, t: Pointer[_EVPMD], impl: Pointer[None])
 use @EVP_DigestUpdate[I32](ctx: Pointer[_EVPCTX] tag, d: Pointer[U8] tag, cnt: USize)
-use @EVP_DigestFinal_ex[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, s: Pointer[USize])
+use @EVP_DigestFinal_ex[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, s: Pointer[U32])
 use @EVP_DigestFinalXOF[I32](ctx: Pointer[_EVPCTX] tag, md: Pointer[U8] tag, len: USize) if "openssl_3.0.x" or "openssl_4.0.x"
 use @EVP_MD_CTX_free[None](ctx: Pointer[_EVPCTX]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
@@ -44,7 +44,7 @@ class Digest
     else
       compile_error "You must select an SSL version to use."
     end
-    @EVP_DigestInit_ex(_ctx, @EVP_md5(), USize(0))
+    @EVP_DigestInit_ex(_ctx, @EVP_md5(), Pointer[None])
 
   new ripemd160() =>
     """
@@ -57,7 +57,7 @@ class Digest
     else
       compile_error "You must select an SSL version to use."
     end
-    @EVP_DigestInit_ex(_ctx, @EVP_ripemd160(), USize(0))
+    @EVP_DigestInit_ex(_ctx, @EVP_ripemd160(), Pointer[None])
 
   new sha1() =>
     """
@@ -70,11 +70,11 @@ class Digest
     else
       compile_error "You must select an SSL version to use."
     end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha1(), USize(0))
+    @EVP_DigestInit_ex(_ctx, @EVP_sha1(), Pointer[None])
 
   new sha224() =>
     """
-    Use the SHA256 algorithm to calculate the hash.
+    Use the SHA224 algorithm to calculate the hash.
     """
     _variable_length = false
     _digest_size = 28
@@ -83,7 +83,7 @@ class Digest
     else
       compile_error "You must select an SSL version to use."
     end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha224(), USize(0))
+    @EVP_DigestInit_ex(_ctx, @EVP_sha224(), Pointer[None])
 
   new sha256() =>
     """
@@ -96,7 +96,7 @@ class Digest
     else
       compile_error "You must select an SSL version to use."
     end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha256(), USize(0))
+    @EVP_DigestInit_ex(_ctx, @EVP_sha256(), Pointer[None])
 
   new sha384() =>
     """
@@ -109,7 +109,7 @@ class Digest
     else
       compile_error "You must select an SSL version to use."
     end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha384(), USize(0))
+    @EVP_DigestInit_ex(_ctx, @EVP_sha384(), Pointer[None])
 
   new sha512() =>
     """
@@ -122,7 +122,7 @@ class Digest
     else
       compile_error "You must select an SSL version to use."
     end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha512(), USize(0))
+    @EVP_DigestInit_ex(_ctx, @EVP_sha512(), Pointer[None])
 
   new shake128(size': USize = 16) =>
     """
@@ -142,7 +142,7 @@ class Digest
         _digest_size = 16
       end
       _ctx = @EVP_MD_CTX_new()
-      @EVP_DigestInit_ex(_ctx, @EVP_shake128(), USize(0))
+      @EVP_DigestInit_ex(_ctx, @EVP_shake128(), Pointer[None])
     else
       compile_error "shake128 is only supported with OpenSSL 1.1.x, 3.0.x, or 4.0.x"
     end
@@ -165,7 +165,7 @@ class Digest
         _digest_size = 32
       end
       _ctx = @EVP_MD_CTX_new()
-      @EVP_DigestInit_ex(_ctx, @EVP_shake256(), USize(0))
+      @EVP_DigestInit_ex(_ctx, @EVP_shake256(), Pointer[None])
     else
       compile_error "shake256 is only supported with OpenSSL 1.1.x, 3.0.x, or 4.0.x"
     end
@@ -194,10 +194,10 @@ class Digest
         if _variable_length then
           @EVP_DigestFinalXOF(_ctx, digest.cpointer(), size)
         else
-          @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[USize])
+          @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[U32])
         end
       elseif "openssl_1.1.x" or "libressl" then
-        @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[USize])
+        @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[U32])
       else
         compile_error "You must select an SSL version to use."
       end

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -35,6 +35,7 @@ actor \nodoc\ Main is TestList
     test(_TestSSLContextSetCiphersAfterDispose)
     test(_TestSSLContextSetVerifyDepthAfterDispose)
     test(_TestSSLContextAllowTlsAfterDispose)
+    test(_TestSSLContextAllowTlsV1u2)
     test(_TestSSLContextClientAfterDispose)
     test(_TestSSLContextServerAfterDispose)
     test(_TestTCPSSLWritev)
@@ -1793,12 +1794,15 @@ class \nodoc\ iso _TestSSLContextSetVerifyDepthAfterDispose is UnitTest
   dereferences the null context on every backend.
 
   There is nothing to observe beyond the call returning, so the context is
-  checked for inertness afterwards.
+  checked for inertness afterwards. The call before the dispose is the only one
+  in the suite that carries a depth into `SSL_CTX_set_verify_depth`.
   """
   fun name(): String => "net/ssl/SSLContext.set_verify_depth/after_dispose"
 
   fun apply(h: TestHelper) =>
     let ctx = SSLContext
+
+    ctx.set_verify_depth(4)
 
     ctx.dispose()
     ctx.set_verify_depth(4)
@@ -1841,6 +1845,112 @@ class \nodoc\ iso _TestSSLContextAllowTlsAfterDispose is UnitTest
     h.assert_false(
       ctx.alpn_set_client_protocols(["h2"]),
       "the context should still be disposed")
+
+class \nodoc\ iso _TestSSLContextAllowTlsV1u2 is UnitTest
+  """
+  `allow_tls_v1_2` takes effect on a live context.
+
+  The context permits TLS 1.2 and nothing else, so disabling TLS 1.2 leaves the
+  handshake no version to negotiate. Re-enabling it clears the option and the
+  handshake completes again.
+
+  The first assertion is the control. Without it, a handshake that failed for
+  an unrelated reason would look like the option taking effect.
+
+  The context is live, so `SSLContext._set_options` and `_clear_options` reach
+  the SSL library rather than returning at the disposed check.
+  """
+  fun name(): String => "net/ssl/SSLContext.allow_tls_v1_2"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(
+      _handshakes(h, false, false),
+      "a context pinned to TLS 1.2 should complete a handshake")
+
+    h.assert_false(
+      _handshakes(h, true, false),
+      "disabling TLS 1.2 should leave no version to negotiate")
+
+    h.assert_true(
+      _handshakes(h, true, true),
+      "re-enabling TLS 1.2 should let the handshake complete again")
+
+  fun _handshakes(h: TestHelper, disable: Bool, reenable: Bool): Bool =>
+    """
+    Whether a client and a server session from a TLS 1.2 only context complete
+    a handshake, having disabled and then re-enabled TLS 1.2 as asked.
+    """
+    let auth = FileAuth(h.env.root)
+    let sslctx =
+      try
+        recover val
+          let ctx = SSLContext
+            .> set_authority(FilePath(auth, "assets/cert.pem"))?
+            .> set_cert(
+                FilePath(auth, "assets/cert.pem"),
+                FilePath(auth, "assets/key.pem"))?
+            .> set_client_verify(false)
+            .> set_server_verify(false)
+            .> set_min_proto_version(Tls1u2Version())?
+            .> set_max_proto_version(Tls1u2Version())?
+          if disable then ctx.allow_tls_v1_2(false) end
+          if reenable then ctx.allow_tls_v1_2(true) end
+          ctx
+        end
+      else
+        h.fail("ssl context setup failed")
+        return false
+      end
+
+    let client: SSL =
+      try
+        sslctx.client()?
+      else
+        h.fail("failed getting ssl client session")
+        return false
+      end
+
+    let server: SSL =
+      try
+        sslctx.server()?
+      else
+        client.dispose()
+        h.fail("failed getting ssl server session")
+        return false
+      end
+
+    let ready = _drive(client, server)
+    client.dispose()
+    server.dispose()
+    ready
+
+  fun _drive(client: SSL, server: SSL): Bool =>
+    """
+    Whether both sides reach `SSLReady` when each side's outgoing bytes are
+    handed straight to the other.
+
+    A handshake with no protocol version left to negotiate fails rather than
+    stalls, so the loop ends on its own. The round cap is a backstop against a
+    session that never settles, not the expected way out.
+    """
+    let max_rounds: USize = 20
+    var rounds: USize = 0
+
+    while
+      (client.state() is SSLHandshake) or (server.state() is SSLHandshake)
+    do
+      if rounds == max_rounds then return false end
+      rounds = rounds + 1
+
+      try
+        _TestSSLTransfer(client, server)?
+        _TestSSLTransfer(server, client)?
+      else
+        return false
+      end
+    end
+
+    (client.state() is SSLReady) and (server.state() is SSLReady)
 
 class \nodoc\ iso _TestSSLContextClientAfterDispose is UnitTest
   """

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -7,7 +7,7 @@ use @SSL_ctrl[ILong](
   parg: Pointer[None])
 use @SSL_new[Pointer[_SSL]](ctx: Pointer[_SSLContext] tag)
 use @SSL_free[None](ssl: Pointer[_SSL] tag)
-use @SSL_set_verify[None](ssl: Pointer[_SSL], mode: I32, cb: Pointer[U8])
+use @SSL_set_verify[None](ssl: Pointer[_SSL], mode: I32, cb: Pointer[None])
 use @BIO_s_mem[Pointer[U8]]()
 use @BIO_new[Pointer[_BIO]](typ: Pointer[U8])
 use @BIO_free[I32](bio: Pointer[_BIO] tag)
@@ -18,10 +18,10 @@ use @SSL_do_handshake[I32](ssl: Pointer[_SSL])
 use @SSL_get0_alpn_selected[None](ssl: Pointer[_SSL] tag, data: Pointer[Pointer[U8] iso],
   len: Pointer[U32]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @SSL_pending[I32](ssl: Pointer[_SSL])
-use @SSL_read[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: U32)
-use @SSL_write[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: U32)
-use @BIO_read[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
-use @BIO_write[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: U32)
+use @SSL_read[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: I32)
+use @SSL_write[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: I32)
+use @BIO_read[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: I32)
+use @BIO_write[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: I32)
 use @SSL_get_error[I32](ssl: Pointer[_SSL], ret: I32)
 use @BIO_ctrl_pending[USize](bio: Pointer[_BIO] tag)
 use @SSL_has_pending[I32](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
@@ -98,7 +98,7 @@ class SSL
     if _ssl.is_null() then error end
 
     let mode = if verify then I32(3) else I32(0) end
-    @SSL_set_verify(_ssl, mode, Pointer[U8])
+    @SSL_set_verify(_ssl, mode, Pointer[None])
 
     _input = @BIO_new(@BIO_s_mem())
     if _input.is_null() then error end
@@ -188,11 +188,11 @@ class SSL
       end
 
       _read_buf.undefined(offset + len)
-      @SSL_read(_ssl, _read_buf.cpointer(offset), len.u32())
+      @SSL_read(_ssl, _read_buf.cpointer(offset), len.i32())
     else
       _read_buf.undefined(offset + len)
       let r =
-        @SSL_read(_ssl, _read_buf.cpointer(offset), len.u32())
+        @SSL_read(_ssl, _read_buf.cpointer(offset), len.i32())
 
       if r <= 0 then
         match @SSL_get_error(_ssl, r)
@@ -249,7 +249,7 @@ class SSL
     if _state isnt SSLReady then error end
 
     if data.size() > 0 then
-      @SSL_write(_ssl, data.cpointer(), data.size().u32())
+      @SSL_write(_ssl, data.cpointer(), data.size().i32())
     end
 
   fun ref receive(data: ByteSeq) =>
@@ -259,7 +259,7 @@ class SSL
     """
     if _ssl.is_null() then return end
 
-    @BIO_write(_input, data.cpointer(), data.size().u32())
+    @BIO_write(_input, data.cpointer(), data.size().i32())
 
     if _state is SSLHandshake then
       let r = @SSL_do_handshake(_ssl)
@@ -294,7 +294,7 @@ class SSL
     if len == 0 then error end
 
     let buf = recover Array[U8] .> undefined(len) end
-    @BIO_read(_output, buf.cpointer(), buf.size().u32())
+    @BIO_read(_output, buf.cpointer(), buf.size().i32())
     buf
 
   fun ref dispose() =>

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -8,13 +8,15 @@ use @memcpy[Pointer[U8]](dst: Pointer[None], src: Pointer[None], n: USize)
 use @SSL_CTX_ctrl[ILong](
   ctx: Pointer[_SSLContext] tag,
   op: I32,
-  arg: ULong,
+  arg: ILong,
   parg: Pointer[None])
 use @TLS_method[Pointer[None]]() if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @SSL_CTX_new[Pointer[_SSLContext]](method: Pointer[None])
 use @SSL_CTX_free[None](ctx: Pointer[_SSLContext] tag)
-use @SSL_CTX_clear_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
-use @SSL_CTX_set_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_CTX_clear_options[U64](ctx: Pointer[_SSLContext] tag, opts: U64) if "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_CTX_clear_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" and not ("openssl_3.0.x" or "openssl_4.0.x")
+use @SSL_CTX_set_options[U64](ctx: Pointer[_SSLContext] tag, opts: U64) if "openssl_3.0.x" or "openssl_4.0.x"
+use @SSL_CTX_set_options[ULong](ctx: Pointer[_SSLContext] tag, opts: ULong) if "openssl_1.1.x" and not ("openssl_3.0.x" or "openssl_4.0.x")
 use @SSL_CTX_use_certificate_chain_file[I32](ctx: Pointer[_SSLContext] tag, file: Pointer[U8] tag)
 use @SSL_CTX_use_PrivateKey_file[I32](ctx: Pointer[_SSLContext] tag, file: Pointer[U8] tag, typ: I32)
 use @SSL_CTX_check_private_key[I32](ctx: Pointer[_SSLContext] tag)
@@ -25,19 +27,19 @@ use @CertOpenSystemStoreA[Pointer[U8] tag](prov: Pointer[U8] tag, protcol: Point
   if windows
 use @CertEnumCertificatesInStore[NullablePointer[_CertContext]](cert_store: Pointer[U8] tag,
   prev_ctx: NullablePointer[_CertContext]) if windows
-use @d2i_X509[Pointer[X509] tag](val_out: Pointer[U8] tag, der_in: Pointer[Pointer[U8]],
-  length: U32)
-use @X509_STORE_add_cert[U32](store: Pointer[U8] tag, x509: Pointer[X509] tag)
+use @d2i_X509[Pointer[X509] tag](val_out: Pointer[Pointer[X509]], der_in: Pointer[Pointer[U8]],
+  length: ILong)
+use @X509_STORE_add_cert[I32](store: Pointer[U8] tag, x509: Pointer[X509] tag)
 use @X509_free[None](x509: Pointer[X509] tag)
 use @SSL_CTX_set_cert_store[None](ctx: Pointer[_SSLContext] tag, store: Pointer[U8] tag)
 use @X509_STORE_free[None](store: Pointer[U8] tag)
-use @CertCloseStore[Bool](store: Pointer[U8] tag, flags: U32) if windows
+use @CertCloseStore[I32](store: Pointer[U8] tag, flags: U32) if windows
 use @SSL_CTX_set_cipher_list[I32](ctx: Pointer[_SSLContext] tag, control: Pointer[U8] tag)
-use @SSL_CTX_set_verify_depth[None](ctx: Pointer[_SSLContext] tag, depth: U32)
+use @SSL_CTX_set_verify_depth[None](ctx: Pointer[_SSLContext] tag, depth: I32)
 use @SSL_CTX_set_alpn_select_cb[None](ctx: Pointer[_SSLContext] tag, cb: _ALPNSelectCallback,
    resolver: ALPNProtocolResolver) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @SSL_CTX_set_alpn_protos[I32](ctx: Pointer[_SSLContext] tag, protos: Pointer[U8] tag,
-  protos_len: USize) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+  protos_len: U32) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
 primitive _SSLContext
 
@@ -50,10 +52,10 @@ primitive _SslCtrlClearOptions fun val apply(): I32 => 77
 // Also, in the version strings the "v" becomes "V" and
 // the underscore "_" becomes "u". So SSL_OP_NO_TLSv1_2
 // _SslOpNo_TlsV1u2.
-primitive _SslOpNoTlsV1    fun val apply(): ULong => 0x04000000
-primitive _SslOpNoTlsV1u2  fun val apply(): ULong => 0x08000000
-primitive _SslOpNoTlsV1u1  fun val apply(): ULong => 0x10000000
-primitive _SslOpNoTlsV1u3  fun val apply(): ULong => 0x20000000
+primitive _SslOpNoTlsV1    fun val apply(): U64 => 0x04000000
+primitive _SslOpNoTlsV1u2  fun val apply(): U64 => 0x08000000
+primitive _SslOpNoTlsV1u1  fun val apply(): U64 => 0x10000000
+primitive _SslOpNoTlsV1u3  fun val apply(): U64 => 0x20000000
 
 
 class val SSLContext
@@ -81,20 +83,24 @@ class val SSLContext
       compile_error "You must select an SSL version to use."
     end
 
-  fun _set_options(opts: ULong) =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
+  fun _set_options(opts: U64) =>
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       @SSL_CTX_set_options(_ctx, opts)
+    elseif "openssl_1.1.x" then
+      @SSL_CTX_set_options(_ctx, opts.ulong())
     elseif "libressl" then
-      @SSL_CTX_ctrl(_ctx, _SslCtrlSetOptions(), opts, Pointer[None])
+      @SSL_CTX_ctrl(_ctx, _SslCtrlSetOptions(), opts.ilong(), Pointer[None])
     else
       compile_error "You must select an SSL version to use."
     end
 
-  fun _clear_options(opts: ULong) =>
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
+  fun _clear_options(opts: U64) =>
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       @SSL_CTX_clear_options(_ctx, opts)
+    elseif "openssl_1.1.x" then
+      @SSL_CTX_clear_options(_ctx, opts.ulong())
     elseif "libressl" then
-      @SSL_CTX_ctrl(_ctx, _SslCtrlClearOptions(), opts, Pointer[None])
+      @SSL_CTX_ctrl(_ctx, _SslCtrlClearOptions(), opts.ilong(), Pointer[None])
     else
       compile_error "You must select an SSL version to use."
     end
@@ -191,8 +197,9 @@ class val SSLContext
 
         while not pContext.is_none() do
           let cert_context = pContext()?
-          let x509 = @d2i_X509(Pointer[U8], addressof cert_context.pbCertEncoded,
-            cert_context.cbCertEncoded)
+          let x509 = @d2i_X509(Pointer[Pointer[X509]],
+            addressof cert_context.pbCertEncoded,
+            cert_context.cbCertEncoded.ilong())
           if not x509.is_null() then
             let result = @X509_STORE_add_cert(x509_store, x509)
             @X509_free(x509)
@@ -237,9 +244,13 @@ class val SSLContext
     """
     Set the verify depth. Defaults to 6. Does nothing if the context has been
     disposed.
+
+    A depth of 2^31 or more arrives at the SSL library as a negative depth.
+    What each backend does with one is undocumented, so do not use a depth that
+    large.
     """
     if not _ctx.is_null() then
-      @SSL_CTX_set_verify_depth(_ctx, depth)
+      @SSL_CTX_set_verify_depth(_ctx, depth.i32())
     end
 
   fun ref set_min_proto_version(version: ULong) ? =>
@@ -255,7 +266,8 @@ class val SSLContext
     if _ctx.is_null() then error end
 
     let result =
-      @SSL_CTX_ctrl(_ctx, _SslCtrlSetMinProtoVersion(), version, Pointer[None])
+      @SSL_CTX_ctrl(
+        _ctx, _SslCtrlSetMinProtoVersion(), version.ilong(), Pointer[None])
     if result == 0 then
       error
     end
@@ -287,7 +299,8 @@ class val SSLContext
     if _ctx.is_null() then error end
 
     let result =
-      @SSL_CTX_ctrl(_ctx, _SslCtrlSetMaxProtoVersion(), version, Pointer[None])
+      @SSL_CTX_ctrl(
+        _ctx, _SslCtrlSetMaxProtoVersion(), version.ilong(), Pointer[None])
     if result == 0 then
       error
     end
@@ -336,7 +349,7 @@ class val SSLContext
         let proto_list = _ALPNProtocolList.from_array(protocols)?
         let result =
           @SSL_CTX_set_alpn_protos(
-            _ctx, proto_list.cpointer(), proto_list.size())
+            _ctx, proto_list.cpointer(), proto_list.size().u32())
         return result == 0
       end
     else
@@ -360,15 +373,16 @@ class val SSLContext
 
       match \exhaustive\ resolver.resolve(proto_arr)
       | let matched: String =>
-      var size = matched.size()
-      if (size > 0) and (size <= 255) then
-        var ptr = matched.cpointer()
-        @memcpy(out, addressof ptr, size.bitwidth() / 8)
-        @memcpy(outlen, addressof size, USize(1))
-        _ALPNMatchResultCode.ok()
-      else
-        _ALPNMatchResultCode.fatal()
-      end
+        let size = matched.size()
+        if (size > 0) and (size <= 255) then
+          var ptr = matched.cpointer()
+          var len = size.u8()
+          @memcpy(out, addressof ptr, USize(0).bytewidth())
+          @memcpy(outlen, addressof len, USize(1))
+          _ALPNMatchResultCode.ok()
+        else
+          _ALPNMatchResultCode.fatal()
+        end
       | ALPNNoAck => _ALPNMatchResultCode.no_ack()
       | ALPNWarning => _ALPNMatchResultCode.warning()
       | ALPNFatal => _ALPNMatchResultCode.fatal()

--- a/ssl/net/x509.pony
+++ b/ssl/net/x509.pony
@@ -6,7 +6,7 @@ use @X509_get_subject_name[Pointer[_X509Name]](cert: Pointer[X509])
 use @X509_NAME_get_text_by_NID[I32](name: Pointer[_X509Name], nid: I32,
   buf: Pointer[U8] tag, len: I32)
 use @X509_get_ext_d2i[Pointer[_GeneralNameStack]](cert: Pointer[X509],
-  nid: I32, crit: Pointer[U8], idx: Pointer[U8])
+  nid: I32, crit: Pointer[I32], idx: Pointer[I32])
 use @OPENSSL_sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
@@ -77,7 +77,7 @@ primitive X509
     end
 
     let stack =
-      @X509_get_ext_d2i(cert, I32(85), Pointer[U8], Pointer[U8])
+      @X509_get_ext_d2i(cert, I32(85), Pointer[I32], Pointer[I32])
 
     if stack.is_null() then
       return array


### PR DESCRIPTION
Sixteen FFI declarations named a Pony type that is the right width on x86-64 and wrong somewhere else. Each one now names the C type from the OpenSSL header.

Two of them were a live bug. `SSL_CTX_set_options` and `SSL_CTX_clear_options` take a `uint64_t` in OpenSSL 3.x and were declared `ULong`, which is 32 bits on every 32-bit target. They are the disable and re-enable paths of `allow_tls_v1`, `allow_tls_v1_1` and `allow_tls_v1_2`. The commit message has the mechanism. This is the evidence, from `ponyc --pass=ir --triple=armv7-unknown-linux-gnueabihf`:

```
on main     declare i32 @SSL_CTX_set_options(ptr, i32)   <- 32 bits
on branch   declare i64 @SSL_CTX_set_options(ptr, i64)
```

against a C prototype of `uint64_t SSL_CTX_set_options(SSL_CTX *, uint64_t)`. I did not run this on 32-bit hardware, and no CI leg does.

The other fourteen are harmless on every platform ponyc builds, and the `_alpn_select_cb` byte copy is a fix for a big-endian target that does not exist. The commit message covers both.

Issue #78 lists five of these declarations and says none of them is a live bug. That was right about the five. The sweep to fix them turned up `SSL_CTX_set_options`, which the issue does not mention. All five of its items are fixed here, so `Closes #78`, but the scope went past what it asked for.

Three declarations that name an opaque C struct as `Pointer[U8]` are left alone. That is #80.

## What the tests can and cannot show

`allow_tls_v1_2` reaches `_set_options` and `_clear_options`, and until now every test that called it used a disposed context, where the null check returns before the SSL library is reached. `_TestSSLContextAllowTlsV1u2` pins a context to TLS 1.2 and asserts three things: that it handshakes at all, that disabling TLS 1.2 stops it, and that re-enabling starts it again. The first is the control. Making `_set_options` set nothing fails the second assertion alone; making `_clear_options` clear nothing fails the third alone.

None of that reaches the bug this PR fixes. CI is 64-bit, where `ULong` and `U64` are the same width and the old declarations produced correct calls. The test checks which option bit gets set and cleared. The 32-bit fix rests on the declaration matching the C prototype, which is what the IR above shows.

The other fourteen are the same. A green suite shows the calls still work. On a 64-bit little-endian machine no assertion behaves differently under the new declarations than under the old ones, so reverting all sixteen would leave the suite green.
