### PR TITLE
Fix ALPN resolver being collected while OpenSSL still holds it

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -52,3 +52,44 @@ This affected 32-bit builds using OpenSSL 3.x or 4.x. 64-bit builds, LibreSSL bu
 
 These methods now change only the protocol version they name.
 
+## Fix ALPN resolver being collected while still in use
+
+Setting an ALPN protocol resolver on an `SSLContext` and then dropping your own reference to it could crash a server. `SSLContext.alpn_set_resolver` hands the resolver to OpenSSL, which keeps a raw pointer to it and calls it during every incoming connection's handshake. Nothing on the Pony side kept the resolver alive, so the garbage collector was free to collect it while OpenSSL still held the pointer. A peer opening a TLS connection then drove the handshake into freed memory.
+
+The resolver now stays alive on its own. The context keeps it alive, and every session made from the context keeps the context alive, so the resolver lives for as long as any session that can use it. There is nothing you have to hold onto by hand.
+
+## Require a val resolver for alpn_set_resolver
+
+`SSLContext.alpn_set_resolver` now takes an `ALPNProtocolResolver val` where it took an `ALPNProtocolResolver box` before, and the `ALPNProtocolResolver` interface is now `val`. An `SSLContext` is shared across actors, so the resolver can run on any of them, and it has to be immutable and safe to share.
+
+`ALPNStandardProtocolResolver` is already `val`, so code using it needs no change. Code that passes a resolver of its own class must pass it as `val`:
+
+```pony
+// Before
+ctx.alpn_set_resolver(MyResolver)
+
+// After
+ctx.alpn_set_resolver(recover val MyResolver end)
+```
+
+## Require a val context for SSLContext.client and server
+
+`SSLContext.client` and `SSLContext.server` now need a `val` context where they worked on a mutable one before. Making a session is what keeps the context, and the ALPN resolver it installed with OpenSSL, alive, and a session can only hold the context if it is `val`.
+
+You configure a context and then make sessions from it, so freeze it to `val` once configuration is done:
+
+```pony
+// Before
+let ctx = SSLContext
+ctx.set_authority(auth_file)?
+let session = ctx.client(hostname)?
+
+// After
+let ctx =
+  recover val
+    SSLContext .> set_authority(auth_file)?
+  end
+let session = ctx.client(hostname)?
+```
+
+`SSLContext.server` changes the same way. Configuration methods like `set_authority` still need a mutable context, so do all configuration before freezing. A `val` context cannot be disposed, so a context you make sessions from is freed when the garbage collector collects it rather than when you call `dispose`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. This projec
 - Fix crash when using a disposed SSL session ([PR #68](https://github.com/ponylang/ssl/pull/68))
 - Fix crashes when using a disposed SSL context ([PR #73](https://github.com/ponylang/ssl/pull/73))
 - Fix allow_tls_v1, allow_tls_v1_1 and allow_tls_v1_2 on 32-bit platforms ([PR #79](https://github.com/ponylang/ssl/pull/79))
+- Fix ALPN resolver being collected while still in use ([PR #81](https://github.com/ponylang/ssl/pull/81))
 
 ### Added
 
@@ -16,6 +17,8 @@ All notable changes to this project will be documented in this file. This projec
 ### Changed
 
 - Add SSLDisposed to SSLState ([PR #68](https://github.com/ponylang/ssl/pull/68))
+- Require a val resolver for alpn_set_resolver ([PR #81](https://github.com/ponylang/ssl/pull/81))
+- Require a val context for SSLContext.client and server ([PR #81](https://github.com/ponylang/ssl/pull/81))
 
 ## [2.1.0] - 2026-04-20
 

--- a/examples/ssl-client-server-example/ssl-client-server-example.pony
+++ b/examples/ssl-client-server-example/ssl-client-server-example.pony
@@ -14,7 +14,7 @@ actor Main
       try
         // paths need to be adjusted to a absolute location or you need to run
         // the example from a location where this relative path will be valid
-        recover
+        recover val
           SSLContext
             .> set_authority(
               FilePath(file_auth, "assets/cert.pem"))?

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -4,6 +4,10 @@ use "itertools"
 use "files"
 use "net"
 
+use @memset[Pointer[None]](dst: Pointer[None], value: I32, n: USize)
+use @pony_ctx[Pointer[None]]()
+use @pony_triggergc[None](ctx: Pointer[None])
+
 actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
@@ -24,6 +28,9 @@ actor \nodoc\ Main is TestList
     test(_TestSSLALPNSelectedAfterDispose)
     test(_TestSSLContextDisposeTwice)
     test(_TestSSLContextALPNSetResolverAfterDispose)
+    test(_TestSSLContextALPNResolverRootedByContext)
+    test(_TestSSLContextALPNResolverRootedBySession)
+    test(_TestSSLContextALPNResolverUnreferenced)
     test(_TestSSLContextALPNSetClientProtocolsAfterDispose)
     test(_TestSSLContextSetMinProtoVersionAfterDispose)
     test(_TestSSLContextSetMaxProtoVersionAfterDispose)
@@ -300,7 +307,7 @@ class \nodoc\ iso _TestTCPSSLClientVerifyFalseWithHostname is UnitTest
     let auth = FileAuth(h.env.root)
     let sslctx =
       try
-        recover
+        recover val
           SSLContext
             .> set_authority(FilePath(auth, "assets/cert.pem"))?
             .> set_cert(
@@ -387,7 +394,7 @@ class \nodoc\ iso _TestTCPSSLPeerCertificateVerify is UnitTest
     let auth = FileAuth(h.env.root)
     let client_ctx =
       try
-        recover
+        recover val
           SSLContext
             .> set_authority(FilePath(auth, "assets/cert.pem"))?
         end
@@ -400,7 +407,7 @@ class \nodoc\ iso _TestTCPSSLPeerCertificateVerify is UnitTest
     // server to check.
     let server_ctx =
       try
-        recover
+        recover val
           SSLContext
             .> set_cert(
                 FilePath(auth, "assets/cert.pem"),
@@ -489,7 +496,7 @@ class \nodoc\ iso _TestTCPSSLPeerCertificateHostnameMismatch is UnitTest
     let auth = FileAuth(h.env.root)
     let client_ctx =
       try
-        recover
+        recover val
           SSLContext
             .> set_authority(FilePath(auth, "assets/cert.pem"))?
         end
@@ -499,7 +506,7 @@ class \nodoc\ iso _TestTCPSSLPeerCertificateHostnameMismatch is UnitTest
       end
     let server_ctx =
       try
-        recover
+        recover val
           SSLContext
             .> set_cert(
                 FilePath(auth, "assets/cert.pem"),
@@ -608,7 +615,7 @@ class \nodoc\ iso _TestWindowsLoadRootCertificates is UnitTest
     try
       let auth = FileAuth(h.env.root)
       let ssl_ctx =
-        recover
+        recover val
           SSLContext
             .>set_authority(None, None)?
             .>set_cert(FilePath(auth, "assets/cert.pem"),
@@ -969,7 +976,7 @@ primitive \nodoc\ _TestSSLContext
     let sslctx =
       try
         let auth = FileAuth(h.env.root)
-        recover
+        recover val
           SSLContext
             .> set_authority(FilePath(auth, "assets/cert.pem"))?
             .> set_cert(
@@ -1441,27 +1448,10 @@ class \nodoc\ iso _TestSSLALPNSelectedAfterDispose is UnitTest
   fun name(): String => "net/ssl/SSL.alpn_selected/after_dispose"
 
   fun apply(h: TestHelper) =>
-    let auth = FileAuth(h.env.root)
-
-    // The resolver is handed to OpenSSL as callback data, which the Pony GC
-    // cannot see. Hold it here so it outlives the handshake.
-    let resolver = ALPNStandardProtocolResolver(["h2"])
-
     let sslctx =
       try
-        recover val
-          SSLContext
-            .> set_authority(FilePath(auth, "assets/cert.pem"))?
-            .> set_cert(
-                FilePath(auth, "assets/cert.pem"),
-                FilePath(auth, "assets/key.pem"))?
-            .> set_client_verify(false)
-            .> set_server_verify(false)
-            .> alpn_set_client_protocols(["h2"])
-            .> alpn_set_resolver(resolver)
-        end
+        _TestALPNContext(h, ALPNStandardProtocolResolver(["h2"]))?
       else
-        h.fail("ssl context setup failed")
         return
       end
 
@@ -1523,8 +1513,6 @@ class \nodoc\ iso _TestSSLContextALPNSetResolverAfterDispose is UnitTest
   fun name(): String => "net/ssl/SSLContext.alpn_set_resolver/after_dispose"
 
   fun apply(h: TestHelper) =>
-    // The resolver is handed to OpenSSL as callback data, which the Pony GC
-    // cannot see. Hold it here so it outlives the context.
     let resolver = ALPNStandardProtocolResolver(["h2"])
     let ctx = SSLContext
 
@@ -1537,6 +1525,296 @@ class \nodoc\ iso _TestSSLContextALPNSetResolverAfterDispose is UnitTest
     h.assert_false(
       ctx.alpn_set_resolver(resolver),
       "alpn_set_resolver() on a disposed context should return false")
+
+class \nodoc\ val _TestALPNTrackedResolver is ALPNProtocolResolver
+  """
+  Resolves every advertisement to "h2" and reports its own collection by writing
+  a byte through `_collected`, a raw pointer into an array a live
+  `_TestALPNResolverTracker` holds.
+  """
+  let _collected: Pointer[U8] tag
+
+  new val create(collected: Pointer[U8] tag) =>
+    _collected = collected
+
+  fun box resolve(advertised: Array[ALPNProtocolName] val): ALPNMatchResult =>
+    "h2"
+
+  fun _final() =>
+    @memset(_collected, I32(1), USize(1))
+
+class \nodoc\ _TestALPNResolverTracker
+  """
+  Reports whether the resolver it hands out has been garbage collected.
+  """
+  embed _flag: Array[U8] = Array[U8].init(0, 1)
+
+  fun box resolver(): _TestALPNTrackedResolver =>
+    """
+    A resolver that reports its collection to this tracker. The tracker does not
+    hold a reference to it: whether something else does is what the tests
+    measure.
+    """
+    _TestALPNTrackedResolver(_flag.cpointer())
+
+  fun box collected(): Bool =>
+    // A one element array cannot fail to index. If it somehow did, treat it as
+    // collected rather than as the resolver still being alive.
+    try _flag(0)? != 0 else true end
+
+primitive \nodoc\ _TestALPNContext
+  fun apply(h: TestHelper, resolver: ALPNProtocolResolver val): SSLContext val ?
+  =>
+    """
+    A context that both advertises and resolves the "h2" protocol, so a session
+    pair made from it negotiates ALPN.
+    """
+    let auth = FileAuth(h.env.root)
+    try
+      recover val
+        SSLContext
+          .> set_authority(FilePath(auth, "assets/cert.pem"))?
+          .> set_cert(
+              FilePath(auth, "assets/cert.pem"),
+              FilePath(auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+          .> alpn_set_client_protocols(["h2"])
+          .> alpn_set_resolver(resolver)
+      end
+    else
+      h.fail("ssl context setup failed")
+      error
+    end
+
+actor \nodoc\ _TestALPNResolverContextRooting
+  """
+  Pony collects between behaviors, so the context is built in one behavior and
+  the resolver checked in the next.
+  """
+  let _h: TestHelper
+  embed _tracker: _TestALPNResolverTracker = _TestALPNResolverTracker
+  var _ctx: (SSLContext val | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be run() =>
+    // `resolver` is a local, so once this behavior returns the context is the
+    // only thing that can be keeping it alive.
+    let resolver = _tracker.resolver()
+
+    try
+      _ctx = _TestALPNContext(_h, resolver)?
+    else
+      _h.complete(false)
+      return
+    end
+
+    @pony_triggergc(@pony_ctx())
+    _check()
+
+  be _check() =>
+    if _tracker.collected() then
+      _h.fail("the context did not keep the resolver alive")
+      _h.complete(false)
+      return
+    end
+
+    let ctx =
+      match _ctx
+      | let c: SSLContext val => c
+      | None =>
+        _h.fail("the context was never created")
+        _h.complete(false)
+        return
+      end
+
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.from_context(_h, ctx)?
+      else
+        _h.complete(false)
+        return
+      end
+
+    match client.alpn_selected()
+    | let protocol: ALPNProtocolName =>
+      _h.assert_eq[String]("h2", protocol)
+    | None =>
+      _h.fail("the client did not negotiate an ALPN protocol")
+    end
+
+    client.dispose()
+    server.dispose()
+    _h.complete(true)
+
+actor \nodoc\ _TestALPNResolverSessionRooting
+  """
+  Pony collects between behaviors, so the sessions are made in one behavior and
+  the resolver checked in the next.
+  """
+  let _h: TestHelper
+  embed _tracker: _TestALPNResolverTracker = _TestALPNResolverTracker
+  var _client: (SSL | None) = None
+  var _server: (SSL | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be run() =>
+    // The resolver and the context are locals, so once this behavior returns
+    // the sessions are the only thing keeping the resolver alive, through the
+    // context they hold.
+    let resolver = _tracker.resolver()
+
+    try
+      let ctx = _TestALPNContext(_h, resolver)?
+      _client = ctx.client()?
+      _server = ctx.server()?
+    else
+      _h.fail("could not create an SSL session pair")
+      _h.complete(false)
+      return
+    end
+
+    @pony_triggergc(@pony_ctx())
+    _check()
+
+  be _check() =>
+    (let client, let server) =
+      try
+        (_client as SSL, _server as SSL)
+      else
+        _h.fail("the sessions were never created")
+        _h.complete(false)
+        return
+      end
+
+    if _tracker.collected() then
+      _h.fail("the sessions did not keep the resolver alive")
+      client.dispose()
+      server.dispose()
+      _h.complete(false)
+      return
+    end
+
+    try
+      _TestSSLSessionPair._handshake(_h, client, server)?
+    else
+      client.dispose()
+      server.dispose()
+      _h.complete(false)
+      return
+    end
+
+    match client.alpn_selected()
+    | let protocol: ALPNProtocolName =>
+      _h.assert_eq[String]("h2", protocol)
+    | None =>
+      _h.fail("the client did not negotiate an ALPN protocol")
+    end
+
+    client.dispose()
+    server.dispose()
+    _h.complete(true)
+
+class \nodoc\ iso _TestSSLContextALPNResolverRootedByContext is UnitTest
+  """
+  A context keeps its ALPN resolver alive.
+
+  `alpn_set_resolver` hands OpenSSL a raw pointer to the resolver, and the Pony
+  garbage collector cannot see it. Without a reference on the Pony side, a
+  collection frees the resolver while OpenSSL still calls it on every later
+  server-side handshake.
+
+  The resolver reports its own collection from `_final`. This test drops every
+  reference to it but the context's, triggers a collection, and then negotiates
+  ALPN through the resolver the context held.
+
+  The negotiation runs only once the resolver is known to be alive. A resolver
+  that was collected would be a use after free, and a crash tells nobody which
+  test caused it.
+  """
+  fun name(): String =>
+    "net/ssl/SSLContext.alpn_set_resolver/resolver_rooted_by_context"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    _TestALPNResolverContextRooting(h).run()
+
+class \nodoc\ iso _TestSSLContextALPNResolverRootedBySession is UnitTest
+  """
+  A session keeps the ALPN resolver alive after the context that made it is
+  dropped.
+
+  `SSL_new` takes a reference on the `SSL_CTX`, so the `SSL_CTX` outlives an
+  `SSLContext` the caller drops while a session is still alive, and the ALPN
+  select callback OpenSSL reads out of it still points at the resolver. A
+  session holds the `SSLContext`, which holds the resolver, so both live as long
+  as the session does. This test keeps only the sessions and drops the context
+  the way a caller would.
+
+  Carries the same caveats as
+  `net/ssl/SSLContext.alpn_set_resolver/resolver_rooted_by_context`.
+  """
+  fun name(): String =>
+    "net/ssl/SSLContext.alpn_set_resolver/resolver_rooted_by_session"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    _TestALPNResolverSessionRooting(h).run()
+
+actor \nodoc\ _TestALPNResolverUnreferenced
+  """
+  Pony collects between behaviors, so the context is built in one behavior and
+  the resolver checked in the next.
+  """
+  let _h: TestHelper
+  embed _tracker: _TestALPNResolverTracker = _TestALPNResolverTracker
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be run() =>
+    // The resolver, the context, and the session are all locals. Once this
+    // behavior returns nothing roots the resolver.
+    let resolver = _tracker.resolver()
+
+    try
+      _TestALPNContext(_h, resolver)?.client()?.dispose()
+    else
+      _h.fail("could not create an SSL session")
+      _h.complete(false)
+      return
+    end
+
+    @pony_triggergc(@pony_ctx())
+    _check()
+
+  be _check() =>
+    _h.assert_true(
+      _tracker.collected(),
+      "a resolver nothing holds should be collected")
+    _h.complete(true)
+
+class \nodoc\ iso _TestSSLContextALPNResolverUnreferenced is UnitTest
+  """
+  A resolver that nothing holds is collected.
+
+  This is the positive control for
+  `net/ssl/SSLContext.alpn_set_resolver/resolver_rooted_by_context` and
+  `..._by_session`, which pass by the resolver *not* being collected. It builds
+  the same resolver, keeps neither the context nor a session, and shows the
+  collection happens. Without it, a change that stopped collections altogether
+  would leave both rooting tests passing for the wrong reason.
+  """
+  fun name(): String =>
+    "net/ssl/SSLContext.alpn_set_resolver/resolver_collected_when_unreferenced"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(2_000_000_000)
+    _TestALPNResolverUnreferenced(h).run()
 
 class \nodoc\ iso _TestSSLContextALPNSetClientProtocolsAfterDispose is UnitTest
   """
@@ -1964,20 +2242,22 @@ class \nodoc\ iso _TestSSLContextClientAfterDispose is UnitTest
   fun name(): String => "net/ssl/SSLContext.client/after_dispose"
 
   fun apply(h: TestHelper) =>
-    let ctx = SSLContext
+    let live: SSLContext val = recover val SSLContext end
 
     try
-      let session = ctx.client()?
-      session.dispose()
+      live.client()?.dispose()
     else
       h.fail("client() on a live context should not raise")
     end
 
-    ctx.dispose()
+    // `client` needs an immutable context, so dispose the mutable one first and
+    // then freeze it to call `client` on the disposed result.
+    let mutable: SSLContext iso = recover iso SSLContext end
+    mutable.dispose()
+    let disposed: SSLContext val = consume mutable
 
     try
-      let session = ctx.client()?
-      session.dispose()
+      disposed.client()?.dispose()
       h.fail("client() on a disposed context should raise")
     end
 
@@ -1993,20 +2273,22 @@ class \nodoc\ iso _TestSSLContextServerAfterDispose is UnitTest
   fun name(): String => "net/ssl/SSLContext.server/after_dispose"
 
   fun apply(h: TestHelper) =>
-    let ctx = SSLContext
+    let live: SSLContext val = recover val SSLContext end
 
     try
-      let session = ctx.server()?
-      session.dispose()
+      live.server()?.dispose()
     else
       h.fail("server() on a live context should not raise")
     end
 
-    ctx.dispose()
+    // `server` needs an immutable context, so dispose the mutable one first and
+    // then freeze it to call `server` on the disposed result.
+    let mutable: SSLContext iso = recover iso SSLContext end
+    mutable.dispose()
+    let disposed: SSLContext val = consume mutable
 
     try
-      let session = ctx.server()?
-      session.dispose()
+      disposed.server()?.dispose()
       h.fail("server() on a disposed context should raise")
     end
 

--- a/ssl/net/alpn.pony
+++ b/ssl/net/alpn.pony
@@ -15,12 +15,16 @@ type _ALPNSelectCallback is @{(
    Pointer[U8] tag,
    Pointer[U8] box,
    U32,
-   ALPNProtocolResolver box)
+   ALPNProtocolResolver val)
   : I32}
 
-interface box ALPNProtocolResolver
+interface val ALPNProtocolResolver
   """
-  Controls the protocol name to be chosen for incomming SSLConnections using the ALPN extension.
+  Controls the protocol name to be chosen for incoming SSL connections using the
+  ALPN extension.
+
+  An implementation is `val`: a context shares the resolver across actors and
+  runs it from any of them, so it cannot depend on mutable state.
   """
   fun box resolve(advertised: Array[ALPNProtocolName] val): ALPNMatchResult
 

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -74,6 +74,11 @@ class SSL
   """
   let _hostname: String
   let _verify: Bool
+  // Nothing reads this. `SSL_new` takes a reference on the `SSL_CTX`, so the
+  // `SSL_CTX` outlives an `SSLContext` the caller drops while this session is
+  // alive. Holding the context here keeps it, and the ALPN resolver it handed
+  // to OpenSSL, alive for as long as the session can drive a handshake.
+  let _context: SSLContext
   var _ssl: Pointer[_SSL] = Pointer[_SSL]
   var _input: Pointer[_BIO] tag = Pointer[_BIO]
   var _output: Pointer[_BIO] tag = Pointer[_BIO]
@@ -81,16 +86,20 @@ class SSL
   var _read_buf: Array[U8] iso = []
 
   new _create(
-    ctx: Pointer[_SSLContext] tag,
+    context: SSLContext val,
     server: Bool,
     verify: Bool,
     hostname: String = "")
     ?
   =>
     """
-    Create a client or server SSL session from a context.
+    Create a client or server SSL session from a context. The session holds the
+    context, so the context and the ALPN resolver it installed with OpenSSL stay
+    alive for as long as the session can handshake.
     """
+    let ctx = context._ssl_ctx()
     if ctx.is_null() then error end
+    _context = context
     _hostname = hostname
     _verify = verify
 

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -37,7 +37,7 @@ use @CertCloseStore[I32](store: Pointer[U8] tag, flags: U32) if windows
 use @SSL_CTX_set_cipher_list[I32](ctx: Pointer[_SSLContext] tag, control: Pointer[U8] tag)
 use @SSL_CTX_set_verify_depth[None](ctx: Pointer[_SSLContext] tag, depth: I32)
 use @SSL_CTX_set_alpn_select_cb[None](ctx: Pointer[_SSLContext] tag, cb: _ALPNSelectCallback,
-   resolver: ALPNProtocolResolver) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+   resolver: ALPNProtocolResolver val) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 use @SSL_CTX_set_alpn_protos[I32](ctx: Pointer[_SSLContext] tag, protos: Pointer[U8] tag,
   protos_len: U32) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
@@ -65,6 +65,9 @@ class val SSLContext
   var _ctx: Pointer[_SSLContext] tag
   var _client_verify: Bool = true
   var _server_verify: Bool = false
+  // OpenSSL holds the raw pointer to this, and the Pony garbage collector
+  // cannot see that. The field is what keeps the resolver alive.
+  var _alpn_resolver: (ALPNProtocolResolver val | None) = None
 
   new create() =>
     """
@@ -105,24 +108,34 @@ class val SSLContext
       compile_error "You must select an SSL version to use."
     end
 
-  fun client(hostname: String = ""): SSL iso^ ? =>
+  fun _ssl_ctx(): Pointer[_SSLContext] tag =>
+    """
+    The raw `SSL_CTX` handle, for a session being created from this context.
+    """
+    _ctx
+
+  fun val client(hostname: String = ""): SSL iso^ ? =>
     """
     Create a client-side SSL session. If a hostname is supplied, the server
     side certificate must be valid for that hostname. Raises an error if the
     context has been disposed.
-    """
-    let ctx = _ctx
-    let verify = _client_verify
-    recover SSL._create(ctx, false, verify, hostname)? end
 
-  fun server(): SSL iso^ ? =>
+    The session holds the context, so the context lives for as long as the
+    session can handshake.
+    """
+    let verify = _client_verify
+    recover SSL._create(this, false, verify, hostname)? end
+
+  fun val server(): SSL iso^ ? =>
     """
     Create a server-side SSL session. Raises an error if the context has been
     disposed.
+
+    The session holds the context, so the context and the ALPN resolver it
+    installed with OpenSSL live for as long as the session can handshake.
     """
-    let ctx = _ctx
     let verify = _server_verify
-    recover SSL._create(ctx, true, verify)? end
+    recover SSL._create(this, true, verify)? end
 
   fun ref set_cert(cert: FilePath, key: FilePath) ? =>
     """
@@ -319,15 +332,24 @@ class val SSLContext
 
     @SSL_CTX_ctrl(_ctx, _SslCtrlGetMaxProtoVersion(), 0, Pointer[None])
 
-  fun ref alpn_set_resolver(resolver: ALPNProtocolResolver box): Bool =>
+  fun ref alpn_set_resolver(resolver: ALPNProtocolResolver val): Bool =>
     """
-    Use `resolver` to choose the protocol to be selected for incomming connections.
+    Use `resolver` to choose the protocol to be selected for incoming
+    connections.
+
+    OpenSSL holds a raw pointer to `resolver` that the Pony garbage collector
+    cannot see. The context keeps `resolver` alive, and every session made from
+    the context keeps the context alive, so `resolver` lives for as long as any
+    session that can reach it. The resolver has to be set before any session is
+    created, which the capabilities enforce: this method needs a mutable
+    context, and `client` and `server` need one that has been made immutable.
 
     Returns true on success. Returns false if the context has been disposed.
     """
     if _ctx.is_null() then return false end
 
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
+      _alpn_resolver = resolver
       @SSL_CTX_set_alpn_select_cb(
         _ctx, addressof SSLContext._alpn_select_cb, resolver)
       return true
@@ -364,7 +386,7 @@ class val SSLContext
     outlen: Pointer[U8] tag,
     inptr: Pointer[U8] box,
     inlen: U32,
-    resolver: ALPNProtocolResolver box)
+    resolver: ALPNProtocolResolver val)
     : I32
   =>
     let proto_arr_str = String.copy_cpointer(inptr, USize.from[U32](inlen))


### PR DESCRIPTION
`SSLContext.alpn_set_resolver` handed the resolver to OpenSSL as ALPN select callback data, and nothing on the Pony side kept it alive. The deeper problem is that a session never held the Pony `SSLContext` that made it — `SSL._create` only took the raw `SSL_CTX` pointer, which keeps the C context alive through a refcount but is invisible to the garbage collector. So the Pony context, and the resolver it holds, could be collected while a session made from it was still handshaking. OpenSSL reads the resolver pointer live from the `SSL_CTX` and calls into freed memory. The trigger is remote: a peer connecting drives a server handshake into the callback.

The fix is that a session now holds its `SSLContext`. The context stays alive as long as any session made from it, and the context holds the current resolver, so the resolver lives as long as anything can call it. That closes the original drop-the-context case and the two follow-on cases — setting the resolver after a session exists, and replacing it — in one move. There is no per-session resolver copy anymore; the context is the single place the resolver is held.

To hold the context, a session, which is `iso` and gets sent between actors, needs a sendable reference to it, and that reference has to be `val` rather than `tag` because the garbage collector does not trace a `tag`'s fields. So `client()` and `server()` now take a `val` receiver, and `alpn_set_resolver` and the `ALPNProtocolResolver` interface take `val`. This also makes the dangerous orderings impossible to write: setting the resolver needs a mutable context, making a session needs an immutable one, and a context is frozen once, so all configuration happens before any session exists.

`ALPNStandardProtocolResolver` is already `val`. Callers configure a context and then make sessions from it, which is already the idiomatic `recover val SSLContext .> ... end` pattern; callers who held a mutable context across session creation now have to freeze it first.

Closes #69. Closes #83.
