### PR TITLE
Fix leaks when loading Windows root certificates fails

### DIFF
--- a/.release-notes/windows-root-cert-leaks.md
+++ b/.release-notes/windows-root-cert-leaks.md
@@ -1,0 +1,9 @@
+## Fix leaks when loading Windows root certificates fails
+
+On Windows, `SSLContext.set_authority(None, None)` loads the system root certificates. Two of its failure paths leaked.
+
+When it could not allocate the certificate store to copy the roots into, it raised an error and left the system certificate store open.
+
+When adding one of the certificates failed partway through, it raised an error and abandoned the certificate it was reading at the time. Windows leaves that one to the caller to release, so its memory was never given back, and the system store's memory could not be released either while it was outstanding.
+
+Both are released now before the error reaches the caller. Only Windows was affected, and only when one of those two calls failed.

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -27,6 +27,7 @@ use @CertOpenSystemStoreA[Pointer[U8] tag](prov: Pointer[U8] tag, protcol: Point
   if windows
 use @CertEnumCertificatesInStore[NullablePointer[_CertContext]](cert_store: Pointer[U8] tag,
   prev_ctx: NullablePointer[_CertContext]) if windows
+use @CertFreeCertificateContext[I32](cert_ctx: NullablePointer[_CertContext]) if windows
 use @d2i_X509[Pointer[X509] tag](val_out: Pointer[Pointer[X509]], der_in: Pointer[Pointer[U8]],
   length: ILong)
 use @X509_STORE_add_cert[I32](store: Pointer[U8] tag, x509: Pointer[X509] tag)
@@ -201,13 +202,17 @@ class val SSLContext
       if hStore.is_null() then error end
 
       let x509_store = @X509_STORE_new()
-      if x509_store.is_null() then error end
+      if x509_store.is_null() then
+        // The `try` below has not started, so its `then` clause will not close
+        // the store.
+        @CertCloseStore(hStore, U32(0))
+        error
+      end
+
+      var pContext = @CertEnumCertificatesInStore(
+        hStore, NullablePointer[_CertContext].none())
 
       try
-        var pContext: NullablePointer[_CertContext]
-        pContext =
-          @CertEnumCertificatesInStore(hStore, NullablePointer[_CertContext].none())
-
         while not pContext.is_none() do
           let cert_context = pContext()?
           let x509 = @d2i_X509(Pointer[Pointer[X509]],
@@ -224,6 +229,13 @@ class val SSLContext
 
         @SSL_CTX_set_cert_store(_ctx, x509_store)
       else
+        // `CertEnumCertificatesInStore` frees the context handed to it as
+        // `prev_ctx`, and returns none when the enumeration is done. Leaving
+        // the loop any other way leaves the last context it returned for the
+        // caller to free.
+        if not pContext.is_none() then
+          @CertFreeCertificateContext(pContext)
+        end
         @X509_STORE_free(x509_store)
       then
         @CertCloseStore(hStore, U32(0))


### PR DESCRIPTION
`_load_windows_root_certs` acquires two things, and its error paths released neither.

The only `CertCloseStore` sits in the `then` clause of a `try`. The `X509_STORE_new` failure raises before that `try` starts, so the system certificate store handle stayed open. `SSL._create` has the same shape and frees `_input` before raising for the same reason, so that is the pattern this copies.

The second leak is not in the issue. `CertEnumCertificatesInStore` frees the context you hand back to it and returns none when the enumeration is done; ending the enumeration any other way leaves the last context it returned for the caller to free. Adding a certificate can fail partway through, which raises out of the loop, and nothing freed that context. `CertFreeCertificateContext` was not declared anywhere in the package. Windows also cannot release the store's memory while a context from it is outstanding, so the second leak held the first one open.

`pContext` moves out of the `try` so the `else` clause can reach the context that was live when the loop raised.

I cannot test this. The code is Windows-only, both paths need an OpenSSL or Windows call to fail, and a leaked Windows handle is not observable from Pony. So this PR adds no test rather than one that proves nothing. What the build does catch is the FFI declaration: ponyc type-checks the untaken `ifdef windows` branch and resolves windows-guarded declarations, which I confirmed by breaking the new `CertFreeCertificateContext` declaration on purpose and watching the Linux build fail.

Closes #76