### PR TITLE
Make ssl/crypto report the failures it was swallowing

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -134,3 +134,45 @@ When a server selected an ALPN protocol, OpenSSL was left with a pointer to memo
 
 One thing changes for you: if you set your own resolver with `SSLContext.alpn_set_resolver` and it returns a protocol the client did not offer, the handshake now fails instead of continuing. `ALPNStandardProtocolResolver` is unaffected.
 
+
+## Make Digest and HmacSha256 raise on failure
+
+`Digest` and `HmacSha256` now raise when OpenSSL cannot do what you asked, where before they returned a wrong result with no error. Three calls gained a `?`: constructing a `Digest`, `Digest.final`, and `HmacSha256`. `Digest.append` was already partial.
+
+```pony
+// Before
+let digest = Digest.sha256()
+digest.append(data)?
+let hash = digest.final()
+
+let mac = HmacSha256(key, message)
+
+// After
+let digest = Digest.sha256()?
+digest.append(data)?
+let hash = digest.final()?
+
+let mac = HmacSha256(key, message)?
+```
+
+Constructing a `Digest` now raises if OpenSSL cannot allocate its context, rather than returning a digest that fails on every later call. When `HmacSha256` raises, reject the message. Do not fall back to a code of your own — a code you make up is one an attacker can send you.
+
+## Fix HmacSha256 returning an all-zero code when it fails
+
+`HmacSha256` returned thirty-two zero bytes when it could not compute the code, instead of failing. Thirty-two zero bytes is a value an attacker can send, so a program that checks a message by comparing a fresh code against a supplied one would accept a forgery whenever its own computation failed.
+
+It was reachable with ordinary input: computing the code of an empty key and an empty message returned all zeros. `HmacSha256` now returns the real code and raises when the computation actually fails.
+
+## Fix Digest returning a wrong hash or crashing when OpenSSL fails
+
+`Digest` could return a hash of the wrong bytes, or crash while being created, when an OpenSSL call inside it failed.
+
+`final` returned a block of memory as the hash without checking that OpenSSL had written it, so a failed call returned whatever that memory held — a wrong hash, and a leak of whatever was last in it. Creating a digest crashed when OpenSSL could not allocate its working context.
+
+A digest now raises rather than returning a wrong hash, and one that could not be created reports it at the first `append` or `final` rather than crashing.
+
+## Fix crypto functions truncating a length too large for an int
+
+`RandBytes`, `HmacSha256` and `Pbkdf2Sha256` silently truncated a length that did not fit the C `int` OpenSSL takes. `RandBytes`, asked for a number of bytes past four gigabytes, returned a buffer of that size with only a handful of random bytes in it and the rest zero, and reported success.
+
+These functions now raise on a length larger than an `int` can hold, before allocating anything.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file. This projec
 - Allow non-mutating methods to be called on a val receiver ([PR #89](https://github.com/ponylang/ssl/pull/89))
 - Fix leaks when loading Windows root certificates fails ([PR #90](https://github.com/ponylang/ssl/pull/90))
 - Fix a potential use-after-free in ALPN protocol selection ([PR #91](https://github.com/ponylang/ssl/pull/91))
+- Fix HmacSha256 returning an all-zero code when it fails ([PR #92](https://github.com/ponylang/ssl/pull/92))
+- Fix Digest returning a wrong hash or crashing when OpenSSL fails ([PR #92](https://github.com/ponylang/ssl/pull/92))
+- Fix crypto functions truncating a length too large for an int ([PR #92](https://github.com/ponylang/ssl/pull/92))
 
 ### Added
 
@@ -23,6 +26,7 @@ All notable changes to this project will be documented in this file. This projec
 - Add SSLDisposed to SSLState ([PR #68](https://github.com/ponylang/ssl/pull/68))
 - Require a val resolver for alpn_set_resolver ([PR #81](https://github.com/ponylang/ssl/pull/81))
 - Require a val context for SSLContext.client and server ([PR #81](https://github.com/ponylang/ssl/pull/81))
+- Make Digest and HmacSha256 raise on failure ([PR #92](https://github.com/ponylang/ssl/pull/92))
 
 ## [2.1.0] - 2026-04-20
 

--- a/examples/digest-example/digest-example.pony
+++ b/examples/digest-example/digest-example.pony
@@ -4,11 +4,11 @@ use "../../ssl/crypto"
 
 actor Main
   new create(env: Env) =>
-    let sha256digest: Digest = Digest.sha256()
+    let sha256digest: Digest = Digest.sha256()?
     try
       sha256digest.append("Hello ")?
       sha256digest.append("World")?
-      let hash: Array[U8] val = sha256digest.final()
+      let hash: Array[U8] val = sha256digest.final()?
       env.out.print("SHA256: " + ToHexString(hash))
     else
       env.out.print("Error computing hash")
@@ -16,11 +16,11 @@ actor Main
 
     // SHAKE256 with variable-length output (OpenSSL 3.0.x or 4.0.x)
     ifdef "openssl_3.0.x" or "openssl_4.0.x" then
-      let shake: Digest = Digest.shake256(64)
+      let shake: Digest = Digest.shake256(64)?
       try
         shake.append("Hello ")?
         shake.append("World")?
-        let shake_hash: Array[U8] val = shake.final()
+        let shake_hash: Array[U8] val = shake.final()?
         env.out.print("SHAKE256 (64 bytes): " + ToHexString(shake_hash))
       else
         env.out.print("Error computing SHAKE hash")

--- a/ssl/crypto/_test.pony
+++ b/ssl/crypto/_test.pony
@@ -26,6 +26,9 @@ actor \nodoc\ Main is TestList
     test(_TestHmacSha256Rfc4231)
     test(_TestHmacSha256Scram)
     test(_TestRandBytes)
+    test(_TestHmacSha256EmptyMessage)
+    test(_TestRandBytesSizeTooLarge)
+    test(_TestPbkdf2Sha256ArgumentsTooLarge)
     test(Property1UnitTest[USize](_TestHmacSha256OutputLength))
     test(Property1UnitTest[USize](_TestHmacSha256Deterministic))
     test(Property1UnitTest[USize](_TestRandBytesOutputLength))
@@ -144,64 +147,64 @@ class \nodoc\ iso _TestDigest is UnitTest
   fun name(): String => "crypto/Digest"
 
   fun apply(h: TestHelper) ? =>
-    let md5 = Digest.md5()
+    let md5 = Digest.md5()?
     md5.append("message1")?
     md5.append("message2")?
     h.assert_eq[String](
       "94af09c09bb9bb7b5c94fec6e6121482",
-      ToHexString(md5.final()))
+      ToHexString(md5.final()?))
 
-    let sha1 = Digest.sha1()
+    let sha1 = Digest.sha1()?
     sha1.append("message1")?
     sha1.append("message2")?
     h.assert_eq[String](
       "942682e2e49f37b4b224fc1aec1a53a25967e7e0",
-      ToHexString(sha1.final()))
+      ToHexString(sha1.final()?))
 
-    let sha224 = Digest.sha224()
+    let sha224 = Digest.sha224()?
     sha224.append("message1")?
     sha224.append("message2")?
     h.assert_eq[String](
       "fbba013f116e8b09b044b2a785ed7fb6a65ce672d724c1fb20500d45",
-      ToHexString(sha224.final()))
+      ToHexString(sha224.final()?))
 
-    let sha256 = Digest.sha256()
+    let sha256 = Digest.sha256()?
     sha256.append("message1")?
     sha256.append("message2")?
     h.assert_eq[String](
       "68d9b867db4bde630f3c96270b2320a31a72aafbc39997eb2bc9cf2da21e5213",
-      ToHexString(sha256.final()))
+      ToHexString(sha256.final()?))
 
-    let sha384 = Digest.sha384()
+    let sha384 = Digest.sha384()?
     sha384.append("message1")?
     sha384.append("message2")?
     h.assert_eq[String](
       "7736dd67494a7072bf255852bd327406b398cb0b16cb400fcd3fcfb6827d74ab"+
       "9b14673d50515b6273ef15543325f8d3",
-      ToHexString(sha384.final()))
+      ToHexString(sha384.final()?))
 
-    let sha512 = Digest.sha512()
+    let sha512 = Digest.sha512()?
     sha512.append("message1")?
     sha512.append("message2")?
     h.assert_eq[String](
       "3511f4825021a90cd55d37db5c3250e6bbcffc9a0d56d88b4e2878ac5b094692"+
       "cd945c6a77006272322f911c9be31fa970043daa4b61cee607566cbfa2c69b09",
-      ToHexString(sha512.final()))
+      ToHexString(sha512.final()?))
 
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
-      let shake128 = Digest.shake128()
+      let shake128 = Digest.shake128()?
       shake128.append("message1")?
       shake128.append("message2")?
       h.assert_eq[String](
       "0d11671f23b6356bdf4ba8dcae37419d",
-      ToHexString(shake128.final()))
+      ToHexString(shake128.final()?))
 
-      let shake256 = Digest.shake256()
+      let shake256 = Digest.shake256()?
       shake256.append("message1")?
       shake256.append("message2")?
       h.assert_eq[String](
       "80e2bbb14639e3b1fc1df80b47b67fb518b0ed26a1caddfa10d68f7992c33820",
-      ToHexString(shake256.final()))
+      ToHexString(shake256.final()?))
     end
 
 class \nodoc\ iso _TestDigestFinalTwice is UnitTest
@@ -218,12 +221,12 @@ class \nodoc\ iso _TestDigestFinalTwice is UnitTest
     let expected =
       "68d9b867db4bde630f3c96270b2320a31a72aafbc39997eb2bc9cf2da21e5213"
 
-    let digest = Digest.sha256()
+    let digest = Digest.sha256()?
     digest.append("message1")?
     digest.append("message2")?
 
-    h.assert_eq[String](expected, ToHexString(digest.final()))
-    h.assert_eq[String](expected, ToHexString(digest.final()))
+    h.assert_eq[String](expected, ToHexString(digest.final()?))
+    h.assert_eq[String](expected, ToHexString(digest.final()?))
 
 class \nodoc\ iso _TestDigestAppendAfterFinal is UnitTest
   """
@@ -236,9 +239,9 @@ class \nodoc\ iso _TestDigestAppendAfterFinal is UnitTest
   fun name(): String => "crypto/Digest/append_after_final"
 
   fun apply(h: TestHelper) ? =>
-    let digest = Digest.sha256()
+    let digest = Digest.sha256()?
     digest.append("message1")?
-    digest.final()
+    digest.final()?
 
     let raised =
       try
@@ -286,10 +289,10 @@ actor \nodoc\ _TestDigestDropRunner
     // The digest and the holder are both locals. Once this behavior returns
     // nothing roots either of them.
     try
-      let digest = Digest.sha256()
+      let digest = Digest.sha256()?
       digest.append("message1")?
       if _finalize then
-        digest.final()
+        digest.final()?
       end
       _TestDigestHolder(_flag.cpointer(), digest)
     else
@@ -350,7 +353,7 @@ class \nodoc\ iso _TestHmacSha256Rfc4231 is UnitTest
   """
   fun name(): String => "crypto/HmacSha256/RFC4231"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     // Test Case 1: Key = 20 bytes of 0x0b, Data = "Hi There"
     let key1 = recover val
       let a = Array[U8].create(20)
@@ -360,12 +363,12 @@ class \nodoc\ iso _TestHmacSha256Rfc4231 is UnitTest
     end
     h.assert_eq[String](
       "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
-      ToHexString(HmacSha256(key1, "Hi There")))
+      ToHexString(HmacSha256(key1, "Hi There")?))
 
     // Test Case 2: Key = "Jefe", Data = "what do ya want for nothing?"
     h.assert_eq[String](
       "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
-      ToHexString(HmacSha256("Jefe", "what do ya want for nothing?")))
+      ToHexString(HmacSha256("Jefe", "what do ya want for nothing?")?))
 
     // Test Case 3: Key = 20 bytes of 0xaa, Data = 50 bytes of 0xdd
     let key3 = recover val
@@ -382,7 +385,7 @@ class \nodoc\ iso _TestHmacSha256Rfc4231 is UnitTest
     end
     h.assert_eq[String](
       "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe",
-      ToHexString(HmacSha256(key3, data3)))
+      ToHexString(HmacSha256(key3, data3)?))
 
     // Test Case 4: Key = 0x01..0x19, Data = 50 bytes of 0xcd
     let key4 = recover val
@@ -399,7 +402,7 @@ class \nodoc\ iso _TestHmacSha256Rfc4231 is UnitTest
     end
     h.assert_eq[String](
       "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b",
-      ToHexString(HmacSha256(key4, data4)))
+      ToHexString(HmacSha256(key4, data4)?))
 
     // Test Case 5: Truncation to 128 bits
     let key5 = recover val
@@ -408,7 +411,7 @@ class \nodoc\ iso _TestHmacSha256Rfc4231 is UnitTest
       while i < 20 do a.push(0x0c); i = i + 1 end
       a
     end
-    let hmac5 = HmacSha256(key5, "Test With Truncation")
+    let hmac5 = HmacSha256(key5, "Test With Truncation")?
     h.assert_eq[String](
       "a3b6167473100ee06e0c796c2955552b",
       ToHexString(recover val
@@ -431,7 +434,7 @@ class \nodoc\ iso _TestHmacSha256Rfc4231 is UnitTest
     h.assert_eq[String](
       "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54",
       ToHexString(HmacSha256(key6,
-        "Test Using Larger Than Block-Size Key - Hash Key First")))
+        "Test Using Larger Than Block-Size Key - Hash Key First")?))
 
     // Test Case 7: Key = 131 bytes of 0xaa, large key + large data
     h.assert_eq[String](
@@ -439,7 +442,7 @@ class \nodoc\ iso _TestHmacSha256Rfc4231 is UnitTest
       ToHexString(HmacSha256(key6,
         "This is a test using a larger than block-size key and a larger " +
         "than block-size data. The key needs to be hashed before being " +
-        "used by the HMAC algorithm.")))
+        "used by the HMAC algorithm.")?))
 
 class \nodoc\ iso _TestHmacSha256Scram is UnitTest
   """
@@ -449,7 +452,7 @@ class \nodoc\ iso _TestHmacSha256Scram is UnitTest
   """
   fun name(): String => "crypto/HmacSha256/SCRAM"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     // SaltedPassword from PBKDF2("pencil", salt, 4096, 32)
     let salted_password = recover val [as U8:
       0xc4; 0xa4; 0x95; 0x10; 0x32; 0x3a; 0xb4; 0xf9
@@ -461,12 +464,12 @@ class \nodoc\ iso _TestHmacSha256Scram is UnitTest
     // HMAC(SaltedPassword, "Client Key")
     h.assert_eq[String](
       "a60fc923d67e8644a92d16b96eda5ef4656b0c725c484374be25535576996e8b",
-      ToHexString(HmacSha256(salted_password, "Client Key")))
+      ToHexString(HmacSha256(salted_password, "Client Key")?))
 
     // HMAC(SaltedPassword, "Server Key")
     h.assert_eq[String](
       "c1f3cbc1c13a9d35a14c0990eed97629ea225863e566a4314ab99f3f00e5d9d5",
-      ToHexString(HmacSha256(salted_password, "Server Key")))
+      ToHexString(HmacSha256(salted_password, "Server Key")?))
 
 class \nodoc\ iso _TestPbkdf2Sha256Rfc7914 is UnitTest
   """
@@ -528,16 +531,123 @@ class \nodoc\ iso _TestRandBytes is UnitTest
 
 // PonyCheck property tests
 
+class \nodoc\ iso _TestHmacSha256EmptyMessage is UnitTest
+  """
+  A code over an empty key or an empty message is the code of that key and
+  message, not thirty-two zero bytes.
+
+  An empty `Array[U8]` has a null pointer, and `HMAC` returns NULL when both the
+  key and the message pointers are null. Without the fix, `HmacSha256` asked
+  OpenSSL for a code over an empty key and an empty message, got nothing back,
+  and returned its zeroed output buffer as the code.
+
+  An empty `String` has a pointer, so the same call written with `""` gives the
+  right answer either way. `Array[U8]` is what a caller holds after decoding a
+  zero-length field off the wire.
+  """
+  fun name(): String => "crypto/HmacSha256/empty_message"
+
+  fun apply(h: TestHelper) ? =>
+    let empty = recover val Array[U8] end
+
+    h.assert_eq[String](
+      "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad",
+      ToHexString(HmacSha256(empty, empty)?),
+      "an empty key and an empty message")
+    h.assert_eq[String](
+      "5f576a8d68fe4fb7eb823227246353c0870c3b0e878997341db1226b4bd88d61",
+      ToHexString(HmacSha256(empty, "msg")?),
+      "an empty key")
+    h.assert_eq[String](
+      "5d5d139563c95b5967b9bd9a8c9b233a9dedb45072794cd232dc1b74832607d0",
+      ToHexString(HmacSha256("key", empty)?),
+      "an empty message")
+
+class \nodoc\ iso _TestRandBytesSizeTooLarge is UnitTest
+  """
+  `RandBytes` raises rather than narrowing a size that OpenSSL's `int` cannot
+  hold.
+
+  `RAND_bytes` takes an `int`. A size of `2^32 + 5` narrows to 5: without the
+  check the array is the full size, `RAND_bytes` fills five bytes of it and
+  reports success, and the caller gets a nonce that is four gigabytes of zeros
+  with five random bytes in it.
+
+  A size between `2^31` and `2^32` narrows to a negative `int`, which
+  `RAND_bytes` rejects on its own. Those sizes raise with or without the check
+  and say nothing about it.
+
+  The check runs before the array is allocated, so this test allocates nothing.
+  """
+  fun name(): String => "crypto/RandBytes/size_too_large"
+
+  fun apply(h: TestHelper) =>
+    ifdef lp64 or llp64 then
+      h.assert_error(
+        {()? => RandBytes(4294967301)? },
+        "a size whose low 32 bits are small should raise")
+    end
+
+    h.assert_error(
+      {()? => RandBytes(I32.max_value().usize() + 1)? },
+      "a size larger than an int should raise")
+
+    try
+      h.assert_eq[USize](32, RandBytes(32)?.size(), "a sane size still works")
+    else
+      h.fail("RandBytes should not raise on a sane size")
+    end
+
+class \nodoc\ iso _TestPbkdf2Sha256ArgumentsTooLarge is UnitTest
+  """
+  `Pbkdf2Sha256` raises rather than narrowing an argument that OpenSSL's `int`
+  cannot hold.
+
+  A key length of `2^32 + 5` narrows to 5: without the check the array is the
+  full length, `PKCS5_PBKDF2_HMAC` writes five bytes of it and reports success,
+  and the rest is zeros.
+
+  The iteration count has no such band. Every `U32` too large for an `int`
+  narrows to a negative one, and OpenSSL 3.x rejects that on its own, so the
+  assertion below holds with or without the check. It is here because the four
+  backends do not agree on what they do with a negative iteration count, and
+  this package should not have to know which one it is talking to.
+
+  Each check runs before the key array is allocated.
+  """
+  fun name(): String => "crypto/Pbkdf2Sha256/arguments_too_large"
+
+  fun apply(h: TestHelper) =>
+    ifdef lp64 or llp64 then
+      h.assert_error(
+        {()? => Pbkdf2Sha256("password", "salt", 4096, 4294967301)? },
+        "a key length whose low 32 bits are small should raise")
+    end
+
+    h.assert_error(
+      {()? =>
+        Pbkdf2Sha256("password", "salt", I32.max_value().u32() + 1, 32)?
+      },
+      "an iteration count larger than an int should raise")
+
+    try
+      h.assert_eq[USize](
+        32, Pbkdf2Sha256("password", "salt", 4096, 32)?.size(),
+        "sane arguments still work")
+    else
+      h.fail("Pbkdf2Sha256 should not raise on sane arguments")
+    end
+
 class \nodoc\ iso _TestHmacSha256OutputLength is Property1[USize]
   fun name(): String => "crypto/HmacSha256/property/output_length"
 
   fun gen(): Generator[USize] =>
     Generators.usize(0, 256)
 
-  fun ref property(sample: USize, h: PropertyHelper) =>
+  fun ref property(sample: USize, h: PropertyHelper) ? =>
     let key = recover val Array[U8].init(0x42, sample) end
     let data = recover val Array[U8].init(0xAB, sample) end
-    h.assert_eq[USize](32, HmacSha256(key, data).size())
+    h.assert_eq[USize](32, HmacSha256(key, data)?.size())
 
 class \nodoc\ iso _TestHmacSha256Deterministic is Property1[USize]
   fun name(): String => "crypto/HmacSha256/property/deterministic"
@@ -545,10 +655,10 @@ class \nodoc\ iso _TestHmacSha256Deterministic is Property1[USize]
   fun gen(): Generator[USize] =>
     Generators.usize(0, 256)
 
-  fun ref property(sample: USize, h: PropertyHelper) =>
+  fun ref property(sample: USize, h: PropertyHelper) ? =>
     let key = recover val Array[U8].init(0x42, sample) end
     let data = recover val Array[U8].init(0xAB, sample) end
-    h.assert_array_eq[U8](HmacSha256(key, data), HmacSha256(key, data))
+    h.assert_array_eq[U8](HmacSha256(key, data)?, HmacSha256(key, data)?)
 
 class \nodoc\ iso _TestPbkdf2Sha256OutputLength is Property1[USize]
   fun name(): String => "crypto/Pbkdf2Sha256/property/output_length"
@@ -605,20 +715,20 @@ class \nodoc\ iso _TestShake128KnownAnswer is UnitTest
 
   fun apply(h: TestHelper) ? =>
     ifdef "openssl_3.0.x" or "openssl_4.0.x" then
-      let d32 = Digest.shake128(32)
+      let d32 = Digest.shake128(32)?
       d32.append("message1")?
       d32.append("message2")?
       h.assert_eq[String](
         "0d11671f23b6356bdf4ba8dcae37419df1d0875e1a15c7859eb3ba0096aa262f",
-        ToHexString(d32.final()))
+        ToHexString(d32.final()?))
 
-      let d64 = Digest.shake128(64)
+      let d64 = Digest.shake128(64)?
       d64.append("message1")?
       d64.append("message2")?
       h.assert_eq[String](
         "0d11671f23b6356bdf4ba8dcae37419df1d0875e1a15c7859eb3ba0096aa262f" +
         "3a1cfc86db5b324ac3f8220645ec0740c2171a0b935f362d0c3bfa5ab51be5d0",
-        ToHexString(d64.final()))
+        ToHexString(d64.final()?))
     end
 
 class \nodoc\ iso _TestShake256KnownAnswer is UnitTest
@@ -631,15 +741,15 @@ class \nodoc\ iso _TestShake256KnownAnswer is UnitTest
 
   fun apply(h: TestHelper) ? =>
     ifdef "openssl_3.0.x" or "openssl_4.0.x" then
-      let d64 = Digest.shake256(64)
+      let d64 = Digest.shake256(64)?
       d64.append("message1")?
       d64.append("message2")?
       h.assert_eq[String](
         "80e2bbb14639e3b1fc1df80b47b67fb518b0ed26a1caddfa10d68f7992c33820" +
         "2d0b17a5ebbcef93f51247497f60bcd3f2809a967874d017ef5b51d6b08836cc",
-        ToHexString(d64.final()))
+        ToHexString(d64.final()?))
 
-      let d128 = Digest.shake256(128)
+      let d128 = Digest.shake256(128)?
       d128.append("message1")?
       d128.append("message2")?
       h.assert_eq[String](
@@ -647,7 +757,7 @@ class \nodoc\ iso _TestShake256KnownAnswer is UnitTest
         "2d0b17a5ebbcef93f51247497f60bcd3f2809a967874d017ef5b51d6b08836cc" +
         "af79f3db3fafdf89e7d42270472c3d1a8e55c52a30859e01b5fceba359c21c1e" +
         "76b73180378604d46061c87e65c4740c8ff9721ed16465cef66fefc3c6f2070c",
-        ToHexString(d128.final()))
+        ToHexString(d128.final()?))
     end
 
 class \nodoc\ iso _TestShake128XofPrefixSmall is Property1[USize]
@@ -667,13 +777,13 @@ class \nodoc\ iso _TestShake128XofPrefixSmall is Property1[USize]
       let small_size = sample / 2
       let large_size = sample
 
-      let small = Digest.shake128(small_size)
+      let small = Digest.shake128(small_size)?
       small.append("test input")?
-      let small_result = small.final()
+      let small_result = small.final()?
 
-      let large = Digest.shake128(large_size)
+      let large = Digest.shake128(large_size)?
       large.append("test input")?
-      let large_result = large.final()
+      let large_result = large.final()?
 
       h.assert_array_eq[U8](small_result,
         large_result.trim(0, small_size))
@@ -698,13 +808,13 @@ class \nodoc\ iso _TestShake128XofPrefix is Property1[USize]
       let small_size = sample / 2
       let large_size = sample
 
-      let small = Digest.shake128(small_size)
+      let small = Digest.shake128(small_size)?
       small.append("test input")?
-      let small_result = small.final()
+      let small_result = small.final()?
 
-      let large = Digest.shake128(large_size)
+      let large = Digest.shake128(large_size)?
       large.append("test input")?
-      let large_result = large.final()
+      let large_result = large.final()?
 
       h.assert_array_eq[U8](small_result,
         large_result.trim(0, small_size))
@@ -732,13 +842,13 @@ class \nodoc\ iso _TestShake256XofPrefixSmall is Property1[USize]
       let small_size = sample / 2
       let large_size = sample
 
-      let small = Digest.shake256(small_size)
+      let small = Digest.shake256(small_size)?
       small.append("test input")?
-      let small_result = small.final()
+      let small_result = small.final()?
 
-      let large = Digest.shake256(large_size)
+      let large = Digest.shake256(large_size)?
       large.append("test input")?
-      let large_result = large.final()
+      let large_result = large.final()?
 
       h.assert_array_eq[U8](small_result,
         large_result.trim(0, small_size))
@@ -763,13 +873,13 @@ class \nodoc\ iso _TestShake256XofPrefix is Property1[USize]
       let small_size = sample / 2
       let large_size = sample
 
-      let small = Digest.shake256(small_size)
+      let small = Digest.shake256(small_size)?
       small.append("test input")?
-      let small_result = small.final()
+      let small_result = small.final()?
 
-      let large = Digest.shake256(large_size)
+      let large = Digest.shake256(large_size)?
       large.append("test input")?
-      let large_result = large.final()
+      let large_result = large.final()?
 
       h.assert_array_eq[U8](small_result,
         large_result.trim(0, small_size))
@@ -823,33 +933,33 @@ class \nodoc\ iso _TestHashFnDigestEquivalence is Property1[USize]
   fun ref property(sample: USize, h: PropertyHelper) ? =>
     let input = recover val Array[U8].init(0x42, sample) end
 
-    let md5 = Digest.md5()
+    let md5 = Digest.md5()?
     md5.append(input)?
-    h.assert_array_eq[U8](MD5(input), md5.final())
+    h.assert_array_eq[U8](MD5(input), md5.final()?)
 
-    let ripemd160 = Digest.ripemd160()
+    let ripemd160 = Digest.ripemd160()?
     ripemd160.append(input)?
-    h.assert_array_eq[U8](RIPEMD160(input), ripemd160.final())
+    h.assert_array_eq[U8](RIPEMD160(input), ripemd160.final()?)
 
-    let sha1 = Digest.sha1()
+    let sha1 = Digest.sha1()?
     sha1.append(input)?
-    h.assert_array_eq[U8](SHA1(input), sha1.final())
+    h.assert_array_eq[U8](SHA1(input), sha1.final()?)
 
-    let sha224 = Digest.sha224()
+    let sha224 = Digest.sha224()?
     sha224.append(input)?
-    h.assert_array_eq[U8](SHA224(input), sha224.final())
+    h.assert_array_eq[U8](SHA224(input), sha224.final()?)
 
-    let sha256 = Digest.sha256()
+    let sha256 = Digest.sha256()?
     sha256.append(input)?
-    h.assert_array_eq[U8](SHA256(input), sha256.final())
+    h.assert_array_eq[U8](SHA256(input), sha256.final()?)
 
-    let sha384 = Digest.sha384()
+    let sha384 = Digest.sha384()?
     sha384.append(input)?
-    h.assert_array_eq[U8](SHA384(input), sha384.final())
+    h.assert_array_eq[U8](SHA384(input), sha384.final()?)
 
-    let sha512 = Digest.sha512()
+    let sha512 = Digest.sha512()?
     sha512.append(input)?
-    h.assert_array_eq[U8](SHA512(input), sha512.final())
+    h.assert_array_eq[U8](SHA512(input), sha512.final()?)
 
 class \nodoc\ iso _TestDigestConcatenation is Property2[USize, USize]
   fun name(): String => "crypto/Digest/property/concatenation"
@@ -870,10 +980,10 @@ class \nodoc\ iso _TestDigestConcatenation is Property2[USize, USize]
       a
     end
 
-    let d = Digest.sha256()
+    let d = Digest.sha256()?
     d.append(part1)?
     d.append(part2)?
-    h.assert_array_eq[U8](SHA256(combined), d.final())
+    h.assert_array_eq[U8](SHA256(combined), d.final()?)
 
 class \nodoc\ iso _TestDigestOutputLength is Property1[USize]
   fun name(): String => "crypto/Digest/property/output_length"
@@ -884,33 +994,33 @@ class \nodoc\ iso _TestDigestOutputLength is Property1[USize]
   fun ref property(sample: USize, h: PropertyHelper) ? =>
     let input = recover val Array[U8].init(0x42, sample) end
 
-    let md5 = Digest.md5()
+    let md5 = Digest.md5()?
     md5.append(input)?
-    h.assert_eq[USize](md5.digest_size(), md5.final().size())
+    h.assert_eq[USize](md5.digest_size(), md5.final()?.size())
 
-    let ripemd160 = Digest.ripemd160()
+    let ripemd160 = Digest.ripemd160()?
     ripemd160.append(input)?
-    h.assert_eq[USize](ripemd160.digest_size(), ripemd160.final().size())
+    h.assert_eq[USize](ripemd160.digest_size(), ripemd160.final()?.size())
 
-    let sha1 = Digest.sha1()
+    let sha1 = Digest.sha1()?
     sha1.append(input)?
-    h.assert_eq[USize](sha1.digest_size(), sha1.final().size())
+    h.assert_eq[USize](sha1.digest_size(), sha1.final()?.size())
 
-    let sha224 = Digest.sha224()
+    let sha224 = Digest.sha224()?
     sha224.append(input)?
-    h.assert_eq[USize](sha224.digest_size(), sha224.final().size())
+    h.assert_eq[USize](sha224.digest_size(), sha224.final()?.size())
 
-    let sha256 = Digest.sha256()
+    let sha256 = Digest.sha256()?
     sha256.append(input)?
-    h.assert_eq[USize](sha256.digest_size(), sha256.final().size())
+    h.assert_eq[USize](sha256.digest_size(), sha256.final()?.size())
 
-    let sha384 = Digest.sha384()
+    let sha384 = Digest.sha384()?
     sha384.append(input)?
-    h.assert_eq[USize](sha384.digest_size(), sha384.final().size())
+    h.assert_eq[USize](sha384.digest_size(), sha384.final()?.size())
 
-    let sha512 = Digest.sha512()
+    let sha512 = Digest.sha512()?
     sha512.append(input)?
-    h.assert_eq[USize](sha512.digest_size(), sha512.final().size())
+    h.assert_eq[USize](sha512.digest_size(), sha512.final()?.size())
 
 class \nodoc\ iso _TestConstantTimeCompareReflexive is Property1[USize]
   fun name(): String =>

--- a/ssl/crypto/crypto.pony
+++ b/ssl/crypto/crypto.pony
@@ -7,6 +7,24 @@ The crypto package provides cryptographic primitives built on OpenSSL:
 * PBKDF2 key derivation (`Pbkdf2Sha256`)
 * Cryptographically secure random bytes (`RandBytes`)
 * Constant-time comparison (`ConstantTimeCompare`)
+
+## When a call can fail
+
+A call here gives back a correct result or it raises. It never gives back an
+incorrect one, so there is no value to check for and no sentinel to compare
+against.
+
+`Digest.append`, `Digest.final`, `HmacSha256`, `Pbkdf2Sha256` and `RandBytes`
+are partial. They raise when OpenSSL could not do what was asked of it.
+`HmacSha256`, `Pbkdf2Sha256` and `RandBytes` also raise when a length you gave
+them is larger than the C `int` OpenSSL takes for it. Constructing a `Digest`
+cannot fail; a context OpenSSL would not give you surfaces at the first
+`append` or `final`.
+
+The one-shot hash functions and `ConstantTimeCompare` cannot fail and are total.
+
+When `HmacSha256` raises, reject the message. Do not compare it against a code
+of your own making — a code you invent is one an attacker can send you.
 """
 
 use @pony_ctx[Pointer[None]]()

--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -23,108 +23,100 @@ use @EVP_shake256[Pointer[_EVPMD]]()
 primitive _EVPMD
 primitive _EVPCTX
 
+primitive _EVPContext
+  fun apply(md: Pointer[_EVPMD]): Pointer[_EVPCTX] ? =>
+    """
+    A context initialised for `md`. Raises when OpenSSL could not give us one.
+
+    This is the only place a `Digest` allocates a context, so a `_ctx` is an
+    initialised and usable one everywhere else.
+    """
+    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
+      let ctx = @EVP_MD_CTX_new()
+      if ctx.is_null() then error end
+
+      if @EVP_DigestInit_ex(ctx, md, Pointer[None]) != 1 then
+        @EVP_MD_CTX_free(ctx)
+        error
+      end
+
+      ctx
+    else
+      compile_error "You must select an SSL version to use."
+    end
+
 class Digest
   """
   Produces a hash from the chunks of input. Feed the input with append() and
   produce a final hash from the concatenation of the input with final().
+
+  A digest gives back the hash of its input, or it raises. It never gives back
+  a hash of something else. Constructing one raises when OpenSSL cannot give it
+  a context; `append()` and `final()` raise when OpenSSL could not do what was
+  asked of them.
   """
   let _digest_size: USize
   var _ctx: Pointer[_EVPCTX] = Pointer[_EVPCTX]
   let _variable_length: Bool
   var _hash: (Array[U8] val | None) = None
 
-  new md5() =>
+  new md5() ? =>
     """
     Use the MD5 algorithm to calculate the hash.
     """
     _variable_length = false
     _digest_size = 16
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
-      _ctx = @EVP_MD_CTX_new()
-    else
-      compile_error "You must select an SSL version to use."
-    end
-    @EVP_DigestInit_ex(_ctx, @EVP_md5(), Pointer[None])
+    _ctx = _EVPContext(@EVP_md5())?
 
-  new ripemd160() =>
+  new ripemd160() ? =>
     """
     Use the RIPEMD160 algorithm to calculate the hash.
     """
     _variable_length = false
     _digest_size = 20
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
-      _ctx = @EVP_MD_CTX_new()
-    else
-      compile_error "You must select an SSL version to use."
-    end
-    @EVP_DigestInit_ex(_ctx, @EVP_ripemd160(), Pointer[None])
+    _ctx = _EVPContext(@EVP_ripemd160())?
 
-  new sha1() =>
+  new sha1() ? =>
     """
     Use the SHA1 algorithm to calculate the hash.
     """
     _variable_length = false
     _digest_size = 20
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
-      _ctx = @EVP_MD_CTX_new()
-    else
-      compile_error "You must select an SSL version to use."
-    end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha1(), Pointer[None])
+    _ctx = _EVPContext(@EVP_sha1())?
 
-  new sha224() =>
+  new sha224() ? =>
     """
     Use the SHA224 algorithm to calculate the hash.
     """
     _variable_length = false
     _digest_size = 28
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
-      _ctx = @EVP_MD_CTX_new()
-    else
-      compile_error "You must select an SSL version to use."
-    end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha224(), Pointer[None])
+    _ctx = _EVPContext(@EVP_sha224())?
 
-  new sha256() =>
+  new sha256() ? =>
     """
     Use the SHA256 algorithm to calculate the hash.
     """
     _variable_length = false
     _digest_size = 32
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
-      _ctx = @EVP_MD_CTX_new()
-    else
-      compile_error "You must select an SSL version to use."
-    end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha256(), Pointer[None])
+    _ctx = _EVPContext(@EVP_sha256())?
 
-  new sha384() =>
+  new sha384() ? =>
     """
     Use the SHA384 algorithm to calculate the hash.
     """
     _variable_length = false
     _digest_size = 48
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
-      _ctx = @EVP_MD_CTX_new()
-    else
-      compile_error "You must select an SSL version to use."
-    end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha384(), Pointer[None])
+    _ctx = _EVPContext(@EVP_sha384())?
 
-  new sha512() =>
+  new sha512() ? =>
     """
     Use the SHA512 algorithm to calculate the hash.
     """
     _variable_length = false
     _digest_size = 64
-    ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
-      _ctx = @EVP_MD_CTX_new()
-    else
-      compile_error "You must select an SSL version to use."
-    end
-    @EVP_DigestInit_ex(_ctx, @EVP_sha512(), Pointer[None])
+    _ctx = _EVPContext(@EVP_sha512())?
 
-  new shake128(size': USize = 16) =>
+  new shake128(size': USize = 16) ? =>
     """
     Use the SHAKE128 algorithm to calculate the hash.
 
@@ -141,13 +133,12 @@ class Digest
         _variable_length = false
         _digest_size = 16
       end
-      _ctx = @EVP_MD_CTX_new()
-      @EVP_DigestInit_ex(_ctx, @EVP_shake128(), Pointer[None])
+      _ctx = _EVPContext(@EVP_shake128())?
     else
       compile_error "shake128 is only supported with OpenSSL 1.1.x, 3.0.x, or 4.0.x"
     end
 
-  new shake256(size': USize = 32) =>
+  new shake256(size': USize = 32) ? =>
     """
     Use the SHAKE256 algorithm to calculate the hash.
 
@@ -164,49 +155,68 @@ class Digest
         _variable_length = false
         _digest_size = 32
       end
-      _ctx = @EVP_MD_CTX_new()
-      @EVP_DigestInit_ex(_ctx, @EVP_shake256(), Pointer[None])
+      _ctx = _EVPContext(@EVP_shake256())?
     else
       compile_error "shake256 is only supported with OpenSSL 1.1.x, 3.0.x, or 4.0.x"
     end
 
   fun ref append(input: ByteSeq) ? =>
     """
-    Update the Digest object with input. Throw an error if final() has been
-    called.
-    """
-    if _hash isnt None then error end
-    @EVP_DigestUpdate(_ctx, input.cpointer(), input.size())
+    Update the digest with input.
 
-  fun ref final(): Array[U8] val =>
+    Raises an error when `final()` has already been called, and when OpenSSL
+    could not take the input.
     """
-    Return the digest of the strings passed to the append() method.
+    if _ctx.is_null() then error end
+    if @EVP_DigestUpdate(_ctx, input.cpointer(), input.size()) != 1 then
+      error
+    end
+
+  fun ref final(): Array[U8] val ? =>
+    """
+    Return the digest of the strings passed to the append() method. A second
+    call returns the hash the first one made.
+
+    Raises an error when OpenSSL could not produce the hash. A digest that
+    raises here has no hash to give, and raises from every later call.
     """
     match _hash
     | let h: Array[U8] val => h
     else
+      if _ctx.is_null() then error end
+
       let size = _digest_size
       let digest =
         recover String.from_cpointer(
           @pony_alloc(@pony_ctx(), size), size)
         end
+
+      var rc: I32 = 0
       ifdef "openssl_3.0.x" or "openssl_4.0.x" then
-        if _variable_length then
-          @EVP_DigestFinalXOF(_ctx, digest.cpointer(), size)
-        else
-          @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[U32])
-        end
+        rc =
+          if _variable_length then
+            @EVP_DigestFinalXOF(_ctx, digest.cpointer(), size)
+          else
+            @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[U32])
+          end
       elseif "openssl_1.1.x" or "libressl" then
-        @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[U32])
+        rc = @EVP_DigestFinal_ex(_ctx, digest.cpointer(), Pointer[U32])
       else
         compile_error "You must select an SSL version to use."
       end
+
       ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
         @EVP_MD_CTX_free(_ctx)
       else
         compile_error "You must select an SSL version to use."
       end
       _ctx = Pointer[_EVPCTX]
+
+      // `@pony_alloc` does not zero the memory it returns, so a digest OpenSSL
+      // did not write holds whatever this actor freed last. Raising drops it
+      // rather than handing it back as a hash.
+      if rc != 1 then error end
+
       let h = (consume digest).array()
       _hash = h
       h

--- a/ssl/crypto/hmac_sha256.pony
+++ b/ssl/crypto/hmac_sha256.pony
@@ -15,16 +15,36 @@ primitive HmacSha256
   Returns a 32-byte message authentication code.
 
   ```pony
-  let mac = HmacSha256("secret-key", "Hello, World!")
+  let mac = HmacSha256("secret-key", "Hello, World!")?
   ```
+
+  Raises an error when the key is longer than OpenSSL's `int` can hold, and when
+  OpenSSL could not compute the code.
+
+  When it raises, reject. Do not compare a message against a code of your own
+  making: a code you invent is one an attacker can send you.
   """
-  fun tag apply(key: ByteSeq, data: ByteSeq): Array[U8] val =>
+  fun tag apply(key: ByteSeq, data: ByteSeq): Array[U8] val ? =>
+    if key.size() > I32.max_value().usize() then error end
+
     recover
       // Use Array.init instead of pony_alloc + from_cpointer to avoid
       // intermittent GC buffer corruption. See ponyc#4831.
       let size: USize = 32
       let arr = Array[U8].init(0, size)
-      @HMAC(@EVP_sha256(), key.cpointer(), key.size().i32(),
-        data.cpointer(), data.size(), arr.cpointer(), Pointer[U32])
+
+      // `HMAC` returns NULL when the message pointer is null, even when the
+      // message is empty, and an empty `Array[U8]` has a null pointer. A code
+      // over an empty message is well defined, so hand it a pointer to bytes it
+      // will not read.
+      let message =
+        if data.size() == 0 then arr.cpointer() else data.cpointer() end
+
+      let md = @HMAC(@EVP_sha256(), key.cpointer(), key.size().i32(),
+        message, data.size(), arr.cpointer(), Pointer[U32])
+
+      // `HMAC` writes nothing when it fails, and `arr` is 32 zero bytes, which
+      // is a code an attacker can send. Raise rather than return it.
+      if md.is_null() then error end
       arr
     end

--- a/ssl/crypto/pbkdf2_sha256.pony
+++ b/ssl/crypto/pbkdf2_sha256.pony
@@ -14,7 +14,9 @@ primitive Pbkdf2Sha256
   as defined in RFC 2898.
 
   Returns a key of the requested length, or raises an error if the derivation
-  fails (e.g., zero iterations).
+  fails (e.g., zero iterations), or if any of the iteration count, the key
+  length, or the password or salt length is larger than OpenSSL's `int` can
+  hold.
 
   ```pony
   let key = Pbkdf2Sha256("password", "salt", 4096, 32)?
@@ -23,6 +25,19 @@ primitive Pbkdf2Sha256
   fun tag apply(password: ByteSeq, salt: ByteSeq, iterations: U32,
     key_length: USize): Array[U8] val ?
   =>
+    // `PKCS5_PBKDF2_HMAC` takes an `int` for the iteration count and for each
+    // length. A value that does not fit one narrows, and the backends do not
+    // agree on what they do with what arrives. Checked before the key array is
+    // allocated.
+    if
+      (password.size() > I32.max_value().usize())
+        or (salt.size() > I32.max_value().usize())
+        or (key_length > I32.max_value().usize())
+        or (iterations > I32.max_value().u32())
+    then
+      error
+    end
+
     ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl" then
       recover
         let arr = Array[U8].init(0, key_length)

--- a/ssl/crypto/rand_bytes.pony
+++ b/ssl/crypto/rand_bytes.pony
@@ -10,13 +10,20 @@ primitive RandBytes
 
   Returns an array of the requested number of random bytes, or raises an
   error if the CSPRNG cannot generate secure output (e.g., insufficient
-  entropy during early system startup).
+  entropy during early system startup), or if `size` is larger than OpenSSL's
+  `int` can hold.
 
   ```pony
   let nonce = RandBytes(24)?
   ```
   """
   fun tag apply(size: USize): Array[U8] val ? =>
+    // `RAND_bytes` takes an `int`. A `size` that does not fit one narrows to a
+    // smaller count, and the bytes past it stay zero while `RAND_bytes` reports
+    // success. Checked before the array is allocated, so an absurd `size` costs
+    // nothing.
+    if size > I32.max_value().usize() then error end
+
     recover
       let arr = Array[U8].init(0, size)
       let rc = @RAND_bytes(arr.cpointer(), size.i32())


### PR DESCRIPTION
The `ssl/crypto` package had two conventions for an OpenSSL failure and no rule. `RandBytes` and `Pbkdf2Sha256` checked the return and raised; `Digest` and `HmacSha256` checked nothing and returned whatever was in the output buffer. This makes the rule uniform: a call returns a correct result or it raises.

**This is a 3.0.0 breaking change.** `Digest`'s constructors, `Digest.final`, and `HmacSha256` are partial now. `Digest.append` was already partial, so a streaming digest was always written inside a `try`.

`HmacSha256` returned thirty-two zero bytes when `HMAC` failed. That is a code an attacker can send: a verifier comparing a computed code against a supplied one accepts when the computation failed. And it was reachable with ordinary input — `HMAC` returns NULL when the key and message pointers are both null, and an empty `Array[U8]` has a null pointer, so `HmacSha256(empty, empty)` returned zeros. Empty keys and messages are well defined; both now get a pointer to bytes HMAC will not read, and a NULL return raises.

`Digest.final` returned its `@pony_alloc` buffer without checking what `EVP_DigestFinal_ex` did to it. That memory is not zeroed, so a failed finalise handed back whatever this actor freed last, as a hash — a wrong answer and a disclosure of freed memory. It raises now.

`EVP_MD_CTX_new` returns NULL when it cannot allocate, and `EVP_DigestInit_ex` then dereferences it and crashes the constructor. The constructors raise there instead, at the one point that knows whether OpenSSL gave a context. Making the constructors partial rather than deferring the failure to `final` means you cannot build an actor around a `Digest` that is doomed to raise on every `final()`.

Six lengths were narrowed to a C `int` unchecked. A length in `[2^31, 2^32)` narrows negative and OpenSSL rejects it. A length past `2^32` narrows to a small positive: `RandBytes(2^32 + 5)` allocated four gigabytes, filled five bytes, was told it succeeded, and returned the lot. Each length is now checked against what an `int` holds, before anything is allocated.

Three guards have no test — nothing in Pony can make OpenSSL fail on demand, and you cannot allocate a 2 GB key in CI: the `HmacSha256` key-length check (the guard #88 names), `Digest.final`'s return check, and the `HMAC` NULL check. Everything else is counterfactualled against main's behavior.

Closes #85
Closes #86
Closes #88