### PR TITLE
Build the examples during make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all clean TAGS test test-one
+.PHONY: all clean TAGS test test-one examples

--- a/examples/digest-example/digest-example.pony
+++ b/examples/digest-example/digest-example.pony
@@ -4,8 +4,8 @@ use "../../ssl/crypto"
 
 actor Main
   new create(env: Env) =>
-    let sha256digest: Digest = Digest.sha256()?
     try
+      let sha256digest: Digest = Digest.sha256()?
       sha256digest.append("Hello ")?
       sha256digest.append("World")?
       let hash: Array[U8] val = sha256digest.final()?
@@ -16,8 +16,8 @@ actor Main
 
     // SHAKE256 with variable-length output (OpenSSL 3.0.x or 4.0.x)
     ifdef "openssl_3.0.x" or "openssl_4.0.x" then
-      let shake: Digest = Digest.shake256(64)?
       try
+        let shake: Digest = Digest.shake256(64)?
         shake.append("Hello ")?
         shake.append("World")?
         let shake_hash: Array[U8] val = shake.final()?


### PR DESCRIPTION
The `examples` target is not in `.PHONY`, and `examples/` is a real directory, so make treated the target as already satisfied and never ran the recipe. `make test` reported success without compiling any example.

Turning the target on surfaced that `digest-example` no longer compiles: it calls `Digest.sha256()` outside a `try`, which stopped being valid when #92 made the `Digest` constructors partial. This fixes the example in the same change, since enabling the guard is what exposes the breakage.

Closes #72
