### PR TITLE
Remove a comment that describes a hazard that does not exist

### DIFF
--- a/ssl/crypto/hmac_sha256.pony
+++ b/ssl/crypto/hmac_sha256.pony
@@ -28,8 +28,6 @@ primitive HmacSha256
     if key.size() > I32.max_value().usize() then error end
 
     recover
-      // Use Array.init instead of pony_alloc + from_cpointer to avoid
-      // intermittent GC buffer corruption. See ponyc#4831.
       let size: USize = 32
       let arr = Array[U8].init(0, size)
 


### PR DESCRIPTION
`ssl/crypto/hmac_sha256.pony` carried a comment claiming `Array.init` avoids GC buffer corruption that `@pony_alloc` plus `from_cpointer` would cause, and citing `ponyc#4831`. `Array[U8].init` allocates through the same `@pony_alloc`, so the garbage collector cannot tell the two apart, and `ponyc#4831` was never filed.

`ssl/crypto/hash_fn.pony` and `ssl/crypto/digest.pony` use `@pony_alloc` plus `from_cpointer` in nine places. A reader who believed the comment read those as latent corruption.

Closes #77
