### PR TITLE
Take a ref receiver on the SSLContext option mutators

### DIFF
--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -87,7 +87,7 @@ class val SSLContext
       compile_error "You must select an SSL version to use."
     end
 
-  fun _set_options(opts: U64) =>
+  fun ref _set_options(opts: U64) =>
     ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       @SSL_CTX_set_options(_ctx, opts)
     elseif "openssl_1.1.x" then
@@ -98,7 +98,7 @@ class val SSLContext
       compile_error "You must select an SSL version to use."
     end
 
-  fun _clear_options(opts: U64) =>
+  fun ref _clear_options(opts: U64) =>
     ifdef "openssl_3.0.x" or "openssl_4.0.x" then
       @SSL_CTX_clear_options(_ctx, opts)
     elseif "openssl_1.1.x" then


### PR DESCRIPTION
`_set_options` and `_clear_options` reconfigure the OpenSSL context but took the default `box` receiver, which a `val` receiver satisfies. An `SSLContext` is held `val` once configuration is done — `client` and `server` require it — so a `fun val` or `fun box` method added later could have reconfigured a frozen context and compiled. They are `fun ref` now, matching every other mutating setter on the type.

Closes #93
