### PR TITLE
Require a box receiver for ssl/crypto's apply methods

### DIFF
--- a/.release-notes/box-receiver-crypto-apply.md
+++ b/.release-notes/box-receiver-crypto-apply.md
@@ -1,0 +1,17 @@
+## Require a box receiver for ssl/crypto's apply methods
+
+The `apply` methods on the eight one-shot hash functions (`MD4`, `MD5`, `RIPEMD160`, `SHA1`, `SHA224`, `SHA256`, `SHA384`, `SHA512`), on `ToHexString`, `RandBytes`, `HmacSha256` and `Pbkdf2Sha256`, and on the `HashFn` interface, took a `tag` receiver. They take a `box` receiver now.
+
+Calling any of them the way you normally would — `MD5("data")`, `HmacSha256(key, message)?` — needs no change. Writing your own `HashFn` needs no change either: a `fun tag apply` still satisfies the interface, and a `fun box apply`, which did not satisfy the `tag` interface before, satisfies it now too.
+
+The one thing that stops compiling is a reference typed `tag`, because a `box` method cannot be called through a `tag`:
+
+```pony
+// Was fine, now a compile error:
+let hash: HashFn tag = SHA256
+hash("data")
+
+// Type the reference val (or box):
+let hash: HashFn val = SHA256
+hash("data")
+```

--- a/ssl/crypto/_test.pony
+++ b/ssl/crypto/_test.pony
@@ -47,6 +47,7 @@ actor \nodoc\ Main is TestList
       test(Property1UnitTest[USize](_TestShake128XofPrefix))
       test(Property1UnitTest[USize](_TestShake256XofPrefix))
     end
+    test(_TestHashFnBoxReceiver)
     test(Property1UnitTest[USize](_TestHashFnOutputLength))
     test(Property1UnitTest[USize](_TestHashFnDeterministic))
     test(Property1UnitTest[USize](_TestHashFnDigestEquivalence))
@@ -889,6 +890,21 @@ class \nodoc\ iso _TestShake256XofPrefix is Property1[USize]
         "e952d90136cb23413ff22b266e2f5dd42294a34bc311394b04863c039011f179",
         ToHexString(large_result.trim(0, 32)))
     end
+
+primitive \nodoc\ _BoxReceiverHashFn is HashFn
+  fun apply(input: ByteSeq): Array[U8] val =>
+    recover val Array[U8].init(0x2A, input.size()) end
+
+class \nodoc\ iso _TestHashFnBoxReceiver is UnitTest
+  """
+  `HashFn.apply` takes a `box` receiver, so a primitive whose `apply` is a
+  plain `fun` satisfies the interface and a `HashFn val` can call it.
+  """
+  fun name(): String => "crypto/HashFn/box_receiver"
+
+  fun apply(h: TestHelper) =>
+    let f: HashFn val = _BoxReceiverHashFn
+    h.assert_array_eq[U8]([as U8: 0x2A; 0x2A; 0x2A], f("abc"))
 
 class \nodoc\ iso _TestHashFnOutputLength is Property1[USize]
   fun name(): String => "crypto/HashFn/property/output_length"

--- a/ssl/crypto/hash_fn.pony
+++ b/ssl/crypto/hash_fn.pony
@@ -17,10 +17,10 @@ interface HashFn
   """
   Produces a fixed-length byte array based on the input sequence.
   """
-  fun tag apply(input: ByteSeq): Array[U8] val
+  fun apply(input: ByteSeq): Array[U8] val
 
 primitive MD4 is HashFn
-  fun tag apply(input: ByteSeq): Array[U8] val =>
+  fun apply(input: ByteSeq): Array[U8] val =>
     """
     Compute the MD4 message digest conforming to RFC 1320
     """
@@ -32,7 +32,7 @@ primitive MD4 is HashFn
     end
 
 primitive MD5 is HashFn
-  fun tag apply(input: ByteSeq): Array[U8] val =>
+  fun apply(input: ByteSeq): Array[U8] val =>
     """
     Compute the MD5 message digest conforming to RFC 1321
     """
@@ -44,7 +44,7 @@ primitive MD5 is HashFn
     end
 
 primitive RIPEMD160 is HashFn
-  fun tag apply(input: ByteSeq): Array[U8] val =>
+  fun apply(input: ByteSeq): Array[U8] val =>
     """
     Compute the RIPEMD160 message digest conforming to ISO/IEC 10118-3
     """
@@ -56,7 +56,7 @@ primitive RIPEMD160 is HashFn
     end
 
 primitive SHA1 is HashFn
-  fun tag apply(input: ByteSeq): Array[U8] val =>
+  fun apply(input: ByteSeq): Array[U8] val =>
     """
     Compute the SHA1 message digest conforming to US Federal Information
     Processing Standard FIPS PUB 180-4
@@ -69,7 +69,7 @@ primitive SHA1 is HashFn
     end
 
 primitive SHA224 is HashFn
-  fun tag apply(input: ByteSeq): Array[U8] val =>
+  fun apply(input: ByteSeq): Array[U8] val =>
     """
     Compute the SHA224 message digest conforming to US Federal Information
     Processing Standard FIPS PUB 180-4
@@ -82,7 +82,7 @@ primitive SHA224 is HashFn
     end
 
 primitive SHA256 is HashFn
-  fun tag apply(input: ByteSeq): Array[U8] val =>
+  fun apply(input: ByteSeq): Array[U8] val =>
     """
     Compute the SHA256 message digest conforming to US Federal Information
     Processing Standard FIPS PUB 180-4
@@ -95,7 +95,7 @@ primitive SHA256 is HashFn
     end
 
 primitive SHA384 is HashFn
-  fun tag apply(input: ByteSeq): Array[U8] val =>
+  fun apply(input: ByteSeq): Array[U8] val =>
     """
     Compute the SHA384 message digest conforming to US Federal Information
     Processing Standard FIPS PUB 180-4
@@ -108,7 +108,7 @@ primitive SHA384 is HashFn
     end
 
 primitive SHA512 is HashFn
-  fun tag apply(input: ByteSeq): Array[U8] val =>
+  fun apply(input: ByteSeq): Array[U8] val =>
     """
     Compute the SHA512 message digest conforming to US Federal Information
     Processing Standard FIPS PUB 180-4
@@ -121,7 +121,7 @@ primitive SHA512 is HashFn
     end
 
 primitive ToHexString
-  fun tag apply(bs: Array[U8] val): String =>
+  fun apply(bs: Array[U8] val): String =>
     """
     Return the lower-case hexadecimal string representation of the given Array
     of U8.

--- a/ssl/crypto/hmac_sha256.pony
+++ b/ssl/crypto/hmac_sha256.pony
@@ -24,7 +24,7 @@ primitive HmacSha256
   When it raises, reject. Do not compare a message against a code of your own
   making: a code you invent is one an attacker can send you.
   """
-  fun tag apply(key: ByteSeq, data: ByteSeq): Array[U8] val ? =>
+  fun apply(key: ByteSeq, data: ByteSeq): Array[U8] val ? =>
     if key.size() > I32.max_value().usize() then error end
 
     recover

--- a/ssl/crypto/pbkdf2_sha256.pony
+++ b/ssl/crypto/pbkdf2_sha256.pony
@@ -22,7 +22,7 @@ primitive Pbkdf2Sha256
   let key = Pbkdf2Sha256("password", "salt", 4096, 32)?
   ```
   """
-  fun tag apply(password: ByteSeq, salt: ByteSeq, iterations: U32,
+  fun apply(password: ByteSeq, salt: ByteSeq, iterations: U32,
     key_length: USize): Array[U8] val ?
   =>
     // `PKCS5_PBKDF2_HMAC` takes an `int` for the iteration count and for each

--- a/ssl/crypto/rand_bytes.pony
+++ b/ssl/crypto/rand_bytes.pony
@@ -17,7 +17,7 @@ primitive RandBytes
   let nonce = RandBytes(24)?
   ```
   """
-  fun tag apply(size: USize): Array[U8] val ? =>
+  fun apply(size: USize): Array[U8] val ? =>
     // `RAND_bytes` takes an `int`. A `size` that does not fit one narrows to a
     // smaller count, and the bytes past it stay zero while `RAND_bytes` reports
     // success. Checked before the array is allocated, so an absurd `size` costs


### PR DESCRIPTION
Every `apply` on `ssl/crypto`'s hash and one-shot primitives, and the `HashFn` interface, was declared `fun tag`. On a fieldless primitive `tag` and `box` compile to the same code, but `tag` forced a `HashFn` implementer to declare `apply` `tag` as well, because a `box` method is not a subtype of a `tag` one. Dropping `tag` widens what satisfies the interface and only breaks calling through a `HashFn tag` reference.

The interface has to lose `tag` before its implementers can, so all thirteen declarations change together.

Closes #94
