### PR TITLE
Declare the opaque C pointers this package declared as Pointer[U8]

### DIFF
--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -8,8 +8,8 @@ use @SSL_ctrl[ILong](
 use @SSL_new[Pointer[_SSL]](ctx: Pointer[_SSLContext] tag)
 use @SSL_free[None](ssl: Pointer[_SSL] tag)
 use @SSL_set_verify[None](ssl: Pointer[_SSL], mode: I32, cb: Pointer[None])
-use @BIO_s_mem[Pointer[U8]]()
-use @BIO_new[Pointer[_BIO]](typ: Pointer[U8])
+use @BIO_s_mem[Pointer[_BIOMethod]]()
+use @BIO_new[Pointer[_BIO]](typ: Pointer[_BIOMethod])
 use @BIO_free[I32](bio: Pointer[_BIO] tag)
 use @SSL_set_bio[None](ssl: Pointer[_SSL], rbio: Pointer[_BIO] tag, wbio: Pointer[_BIO] tag)
 use @SSL_set_accept_state[None](ssl: Pointer[_SSL])
@@ -30,6 +30,7 @@ use @SSL_get1_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_3.
 
 primitive _SSL
 primitive _BIO
+primitive _BIOMethod
 
 primitive SSLHandshake
   """

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -22,19 +22,20 @@ use @SSL_CTX_use_PrivateKey_file[I32](ctx: Pointer[_SSLContext] tag, file: Point
 use @SSL_CTX_check_private_key[I32](ctx: Pointer[_SSLContext] tag)
 use @SSL_CTX_load_verify_locations[I32](ctx: Pointer[_SSLContext] tag, ca_file: Pointer[U8] tag,
   ca_path: Pointer[U8] tag)
-use @X509_STORE_new[Pointer[U8] tag]()
-use @CertOpenSystemStoreA[Pointer[U8] tag](prov: Pointer[U8] tag, protcol: Pointer[U8] tag)
+use @X509_STORE_new[Pointer[_X509Store] tag]()
+use @CertOpenSystemStoreA[Pointer[_CertStore] tag](prov: Pointer[None], protocol: Pointer[U8] tag)
   if windows
-use @CertEnumCertificatesInStore[NullablePointer[_CertContext]](cert_store: Pointer[U8] tag,
+use @CertEnumCertificatesInStore[NullablePointer[_CertContext]](cert_store: Pointer[_CertStore] tag,
   prev_ctx: NullablePointer[_CertContext]) if windows
 use @CertFreeCertificateContext[I32](cert_ctx: NullablePointer[_CertContext]) if windows
 use @d2i_X509[Pointer[X509] tag](val_out: Pointer[Pointer[X509]], der_in: Pointer[Pointer[U8]],
   length: ILong)
-use @X509_STORE_add_cert[I32](store: Pointer[U8] tag, x509: Pointer[X509] tag)
+use @X509_STORE_add_cert[I32](store: Pointer[_X509Store] tag,
+  x509: Pointer[X509] tag)
 use @X509_free[None](x509: Pointer[X509] tag)
-use @SSL_CTX_set_cert_store[None](ctx: Pointer[_SSLContext] tag, store: Pointer[U8] tag)
-use @X509_STORE_free[None](store: Pointer[U8] tag)
-use @CertCloseStore[I32](store: Pointer[U8] tag, flags: U32) if windows
+use @SSL_CTX_set_cert_store[None](ctx: Pointer[_SSLContext] tag, store: Pointer[_X509Store] tag)
+use @X509_STORE_free[None](store: Pointer[_X509Store] tag)
+use @CertCloseStore[I32](store: Pointer[_CertStore] tag, flags: U32) if windows
 use @SSL_CTX_set_cipher_list[I32](ctx: Pointer[_SSLContext] tag, control: Pointer[U8] tag)
 use @SSL_CTX_set_verify_depth[None](ctx: Pointer[_SSLContext] tag, depth: I32)
 use @SSL_CTX_set_alpn_select_cb[None](ctx: Pointer[_SSLContext] tag, cb: _ALPNSelectCallback,
@@ -43,6 +44,8 @@ use @SSL_CTX_set_alpn_protos[I32](ctx: Pointer[_SSLContext] tag, protos: Pointer
   protos_len: U32) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
 
 primitive _SSLContext
+primitive _X509Store
+primitive _CertStore
 
 primitive _SslCtrlSetOptions   fun val apply(): I32 => 32
 primitive _SslCtrlClearOptions fun val apply(): I32 => 77
@@ -198,7 +201,7 @@ class val SSLContext
   fun ref _load_windows_root_certs() ? =>
     ifdef windows then
       let root_str = "ROOT"
-      let hStore = @CertOpenSystemStoreA(Pointer[U8], root_str.cstring())
+      let hStore = @CertOpenSystemStoreA(Pointer[None], root_str.cstring())
       if hStore.is_null() then error end
 
       let x509_store = @X509_STORE_new()

--- a/ssl/net/x509.pony
+++ b/ssl/net/x509.pony
@@ -11,11 +11,11 @@ use @OPENSSL_sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @sk_pop[Pointer[_GeneralName]](stack: Pointer[_GeneralNameStack])
   if "libressl"
-use @GENERAL_NAME_get0_value[Pointer[U8] tag](name: Pointer[_GeneralName],
-  ptype: Pointer[I32])
-use @ASN1_STRING_type[I32](value: Pointer[U8] tag)
-use @ASN1_STRING_get0_data[Pointer[U8]](value: Pointer[U8] tag)
-use @ASN1_STRING_length[I32](value: Pointer[U8] tag)
+use @GENERAL_NAME_get0_value[Pointer[_Asn1String] tag](
+  name: Pointer[_GeneralName], ptype: Pointer[I32])
+use @ASN1_STRING_type[I32](value: Pointer[_Asn1String] tag)
+use @ASN1_STRING_get0_data[Pointer[U8]](value: Pointer[_Asn1String] tag)
+use @ASN1_STRING_length[I32](value: Pointer[_Asn1String] tag)
 use @GENERAL_NAME_free[None](name: Pointer[_GeneralName])
 use @OPENSSL_sk_free[None](stack: Pointer[_GeneralNameStack])
   if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
@@ -25,6 +25,7 @@ use @sk_free[None](stack: Pointer[_GeneralNameStack])
 primitive _X509Name
 primitive _GeneralName
 primitive _GeneralNameStack
+primitive _Asn1String
 
 primitive X509
   fun valid_for_host(cert: Pointer[X509], host: String): Bool =>


### PR DESCRIPTION
`X509_STORE *`, `HCERTSTORE` and `ASN1_STRING *` were declared `Pointer[U8] tag`, so the type checker could not tell them apart. `_load_windows_root_certs` holds an `HCERTSTORE` and an `X509_STORE *` and frees them with different C functions; swapping those arguments compiled.

`BIO_METHOD *` had the same declaration mistake, in `BIO_s_mem` and `BIO_new`. It is not named in the issue, but it is the same cause and lets any `Pointer[U8]` reach `BIO_new`, so it is fixed here too. `CertOpenSystemStoreA`'s `prov`, an `HCRYPTPROV_LEGACY` only ever passed null, becomes `Pointer[None]`, which is what AGENTS.md prescribes.

`ASN1_STRING_get0_data` returns `const unsigned char *`, so its return stays `Pointer[U8]`.

Closes #80
