### PR TITLE
Give the impossible deref an error path that means something

### DIFF
--- a/ssl/net/ssl_connection.pony
+++ b/ssl/net/ssl_connection.pony
@@ -149,8 +149,9 @@ class SSLConnection is TCPConnectionNotify
         end
 
         try
-          while _pending.size() > 0 do
-            _ssl.write(_pending.shift()?)?
+          while true do
+            let bytes = try _pending.shift()? else break end
+            _ssl.write(bytes)?
           end
         end
       end

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -213,8 +213,10 @@ class val SSLContext
         hStore, NullablePointer[_CertContext].none())
 
       try
-        while not pContext.is_none() do
-          let cert_context = pContext()?
+        while true do
+          // `CertEnumCertificatesInStore` returns null when there is no next
+          // certificate, so a null `pContext` is the end of the enumeration.
+          let cert_context = try pContext()? else break end
           let x509 = @d2i_X509(Pointer[Pointer[X509]],
             addressof cert_context.pbCertEncoded,
             cert_context.cbCertEncoded.ilong())


### PR DESCRIPTION
Two loops dereferenced a value whose only error case the loop guard had already ruled out, inside a `try` that also catches a genuinely reachable error. The impossible case, had it ever fired, would have been swallowed: the Windows root-cert loader would have reported success without installing the certificate store, and the handshake-complete drain would have dropped the rest of the queued writes.

Each guard says the same thing the deref's error says, so the guard is gone and the `?` now carries the meaning — the end of the certificate enumeration, and the queue being drained. The `else`/`then` cleanup on the Windows path is unchanged.

Closes #95
