### PR TITLE
Stop three test docstrings from describing other tests

### DIFF
--- a/ssl/crypto/_test.pony
+++ b/ssl/crypto/_test.pony
@@ -764,8 +764,9 @@ class \nodoc\ iso _TestShake128XofPrefixSmall is Property1[USize]
   """
   SHAKE128 prefix property at small output sizes (2..15 bytes). Exercises
   the truncation path where off-by-one partial-block bugs typically live.
-  No KAT anchor — sizes below 16 are guarded by _TestShake128XofPrefix
-  at larger sizes.
+
+  Both results are checked against a known answer as well. Prefix equality on
+  its own holds for an implementation that writes nothing.
   """
   fun name(): String => "crypto/Shake128/property/xof_prefix_small"
 
@@ -787,6 +788,16 @@ class \nodoc\ iso _TestShake128XofPrefixSmall is Property1[USize]
 
       h.assert_array_eq[U8](small_result,
         large_result.trim(0, small_size))
+
+      // The first 16 bytes of SHAKE128("test input"). The generator stops at
+      // 15, so every size it produces is inside the anchor.
+      let kat = "a9d2b0362d0e2e961eeb969ce9a42f2d"
+      h.assert_eq[String](
+        kat.substring(0, (small_size * 2).isize()),
+        ToHexString(small_result))
+      h.assert_eq[String](
+        kat.substring(0, (large_size * 2).isize()),
+        ToHexString(large_result))
     end
 
 class \nodoc\ iso _TestShake128XofPrefix is Property1[USize]
@@ -829,8 +840,9 @@ class \nodoc\ iso _TestShake256XofPrefixSmall is Property1[USize]
   """
   SHAKE256 prefix property at small output sizes (2..31 bytes). Exercises
   the truncation path where off-by-one partial-block bugs typically live.
-  No KAT anchor — sizes below 32 are guarded by _TestShake256XofPrefix
-  at larger sizes.
+
+  Both results are checked against a known answer as well. Prefix equality on
+  its own holds for an implementation that writes nothing.
   """
   fun name(): String => "crypto/Shake256/property/xof_prefix_small"
 
@@ -852,6 +864,17 @@ class \nodoc\ iso _TestShake256XofPrefixSmall is Property1[USize]
 
       h.assert_array_eq[U8](small_result,
         large_result.trim(0, small_size))
+
+      // The first 32 bytes of SHAKE256("test input"). The generator stops at
+      // 31, so every size it produces is inside the anchor.
+      let kat =
+        "e952d90136cb23413ff22b266e2f5dd42294a34bc311394b04863c039011f179"
+      h.assert_eq[String](
+        kat.substring(0, (small_size * 2).isize()),
+        ToHexString(small_result))
+      h.assert_eq[String](
+        kat.substring(0, (large_size * 2).isize()),
+        ToHexString(large_result))
     end
 
 class \nodoc\ iso _TestShake256XofPrefix is Property1[USize]

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -569,23 +569,19 @@ class \nodoc\ _TestTCPSSLPeerCertificateVerifyServerNotify is TCPConnectionNotif
 
 class \nodoc\ iso _TestTCPSSLPeerCertificateHostnameMismatch is UnitTest
   """
-  TLS handshake with the default `_client_verify = true` and a hostname
-  NOT matching the test certificate's SAN. The handshake itself succeeds
-  (self-signed CA is trusted) but X509.valid_for_host rejects the
-  hostname, SSL state becomes SSLAuthFail, and SSLConnection forwards
-  `auth_failed` to the wrapped notify. Complements the positive test by
-  proving that hostname matching actually gates the outcome; without
-  this, a trivially broken `valid_for_host` that always returned true
-  would pass the positive test.
+  TLS handshake with the default `_client_verify = true` and a hostname that
+  does not match the test certificate's SAN. The handshake itself succeeds,
+  because the certificate is signed by an authority the client trusts.
+  `X509.valid_for_host` then rejects the hostname, the SSL state becomes
+  `SSLAuthFail`, and `SSLConnection` forwards `auth_failed` to the wrapped
+  notify.
 
-  Uses separate client and server SSLContexts for the same reason as
-  the positive test — see `_TestTCPSSLPeerCertificateVerify`.
+  The client and server use separate `SSLContext`s. The client's carries no
+  certificate of its own, only the authority, so nothing but the peer's
+  certificate can satisfy the check.
 
-  Note: the test asserts SSLAuthFail is reached but cannot by itself
-  distinguish a hostname-mismatch failure from any other auth failure
-  (e.g. chain validation). The pair with `_TestTCPSSLPeerCertificateVerify`
-  — which would also fail under a broken chain — provides the
-  distinguishing signal.
+  Reaching `SSLAuthFail` does not on its own say that the hostname is what
+  failed. A broken chain would land here too.
   """
   fun name(): String => "net/TCPSSL.peer_certificate_hostname_mismatch"
   fun exclusion_group(): String => "network"


### PR DESCRIPTION
Three test docstrings described another test's coverage — a fact about which tests exist and what they generate, which nothing rebuilds when either changes.

The two small-size SHAKE property tests said their sizes were covered by the larger-size tests. That was also the only thing standing between them and an implementation that writes nothing, since prefix equality holds for an all-zero buffer. They now anchor their results against the same known answer the larger tests use, so the coverage is their own.

`_TestTCPSSLPeerCertificateHostnameMismatch` named the positive test to say what it could not distinguish on its own. It states what it asserts now, keeping the real limitation without naming the other test.

Closes #87
