### PR TITLE
Rename the SSL, TLS and DTLS version primitives

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -40,7 +40,7 @@ Code that read `state()` after a dispose to recover the state the session was in
 
 Calling a method on an `SSLContext` after `dispose()` could crash the program. `alpn_set_resolver` and `alpn_set_client_protocols` crashed against every SSL backend. `set_min_proto_version`, `set_max_proto_version`, `get_min_proto_version` and `get_max_proto_version` crashed against LibreSSL. `set_authority(None, None)`, which loads the system root certificates, crashed on Windows.
 
-A disposed context is now inert, and every backend treats it the same. `alpn_set_resolver` and `alpn_set_client_protocols` return `false`. `set_min_proto_version` and `set_max_proto_version` raise an error, and `get_min_proto_version` and `get_max_proto_version` return `SslAutoVersion`. `set_authority` raises an error whether or not you hand it a file.
+A disposed context is now inert, and every backend treats it the same. `alpn_set_resolver` and `alpn_set_client_protocols` return `false`. `set_min_proto_version` and `set_max_proto_version` raise an error, and `get_min_proto_version` and `get_max_proto_version` return `SSLAutoVersion`. `set_authority` raises an error whether or not you hand it a file.
 
 `client` and `server` on a disposed context raised an error, which is what they should do, and could then crash the program the next time the garbage collector ran. The crash landed far from the call that caused it. That no longer happens.
 

--- a/.release-notes/rename-version-primitives.md
+++ b/.release-notes/rename-version-primitives.md
@@ -1,0 +1,30 @@
+## Rename the SSL, TLS and DTLS version primitives
+
+The twelve primitives you hand to `SSLContext.set_min_proto_version` and `set_max_proto_version` spelled their acronyms `Ssl`, `Tls` and `Dtls`. Everything else in the package spells them out — `SSLContext`, `SSLConnection`, `SSLReady`. The version primitives do now too.
+
+| Before | After |
+| --- | --- |
+| `SslAutoVersion` | `SSLAutoVersion` |
+| `Ssl3Version` | `SSL3Version` |
+| `Tls1Version` | `TLS1Version` |
+| `Tls1u1Version` | `TLS1u1Version` |
+| `Tls1u2Version` | `TLS1u2Version` |
+| `Tls1u3Version` | `TLS1u3Version` |
+| `TlsMinVersion` | `TLSMinVersion` |
+| `TlsMaxVersion` | `TLSMaxVersion` |
+| `Dtls1Version` | `DTLS1Version` |
+| `Dtls1u2Version` | `DTLS1u2Version` |
+| `DtlsMinVersion` | `DTLSMinVersion` |
+| `DtlsMaxVersion` | `DTLSMaxVersion` |
+
+```pony
+// Before
+ctx.set_min_proto_version(Tls1u2Version())?
+ctx.set_max_proto_version(SslAutoVersion())?
+
+// After
+ctx.set_min_proto_version(TLS1u2Version())?
+ctx.set_max_proto_version(SSLAutoVersion())?
+```
+
+The values and the behavior are unchanged. Rename the call sites and you are done.

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -2040,7 +2040,7 @@ class \nodoc\ iso _TestSSLContextSetMinProtoVersionAfterDispose is UnitTest
     let ctx = SSLContext
 
     try
-      ctx.set_min_proto_version(Tls1u2Version())?
+      ctx.set_min_proto_version(TLS1u2Version())?
     else
       h.fail("set_min_proto_version() on a live context should not raise")
     end
@@ -2048,7 +2048,7 @@ class \nodoc\ iso _TestSSLContextSetMinProtoVersionAfterDispose is UnitTest
     ctx.dispose()
 
     try
-      ctx.set_min_proto_version(Tls1u2Version())?
+      ctx.set_min_proto_version(TLS1u2Version())?
       h.fail("set_min_proto_version() on a disposed context should raise")
     end
 
@@ -2067,7 +2067,7 @@ class \nodoc\ iso _TestSSLContextSetMaxProtoVersionAfterDispose is UnitTest
     let ctx = SSLContext
 
     try
-      ctx.set_max_proto_version(Tls1u3Version())?
+      ctx.set_max_proto_version(TLS1u3Version())?
     else
       h.fail("set_max_proto_version() on a live context should not raise")
     end
@@ -2075,16 +2075,16 @@ class \nodoc\ iso _TestSSLContextSetMaxProtoVersionAfterDispose is UnitTest
     ctx.dispose()
 
     try
-      ctx.set_max_proto_version(Tls1u3Version())?
+      ctx.set_max_proto_version(TLS1u3Version())?
       h.fail("set_max_proto_version() on a disposed context should raise")
     end
 
 class \nodoc\ iso _TestSSLContextGetMinProtoVersionAfterDispose is UnitTest
   """
-  `get_min_proto_version` on a disposed context returns `SslAutoVersion` rather
+  `get_min_proto_version` on a disposed context returns `SSLAutoVersion` rather
   than passing a null `SSL_CTX*` to `SSL_CTX_ctrl`.
 
-  `create` sets the minimum to `Tls1u2Version`, so the `SslAutoVersion`
+  `create` sets the minimum to `TLS1u2Version`, so the `SSLAutoVersion`
   afterwards is not the value a live context would have returned.
 
   This test passes with and without the disposed check on OpenSSL, whose
@@ -2097,25 +2097,25 @@ class \nodoc\ iso _TestSSLContextGetMinProtoVersionAfterDispose is UnitTest
     let ctx = SSLContext
 
     h.assert_eq[ILong](
-      Tls1u2Version().ilong(),
+      TLS1u2Version().ilong(),
       ctx.get_min_proto_version(),
       "create() should have set the minimum protocol version to TLS v1.2")
 
     ctx.dispose()
 
     h.assert_eq[ILong](
-      SslAutoVersion().ilong(),
+      SSLAutoVersion().ilong(),
       ctx.get_min_proto_version(),
       "get_min_proto_version() on a disposed context should return "
-        + "SslAutoVersion")
+        + "SSLAutoVersion")
 
 class \nodoc\ iso _TestSSLContextGetMaxProtoVersionAfterDispose is UnitTest
   """
-  `get_max_proto_version` on a disposed context returns `SslAutoVersion` rather
+  `get_max_proto_version` on a disposed context returns `SSLAutoVersion` rather
   than passing a null `SSL_CTX*` to `SSL_CTX_ctrl`.
 
-  `create` leaves the maximum at `SslAutoVersion`, so this test sets it to
-  `Tls1u3Version` first. Without that, the assertion after the dispose would
+  `create` leaves the maximum at `SSLAutoVersion`, so this test sets it to
+  `TLS1u3Version` first. Without that, the assertion after the dispose would
   hold for a live context too.
 
   Carries the same caveat as
@@ -2128,24 +2128,24 @@ class \nodoc\ iso _TestSSLContextGetMaxProtoVersionAfterDispose is UnitTest
     let ctx = SSLContext
 
     try
-      ctx.set_max_proto_version(Tls1u3Version())?
+      ctx.set_max_proto_version(TLS1u3Version())?
     else
       h.fail("set_max_proto_version() on a live context should not raise")
       return
     end
 
     h.assert_eq[ILong](
-      Tls1u3Version().ilong(),
+      TLS1u3Version().ilong(),
       ctx.get_max_proto_version(),
       "the maximum protocol version should read back as TLS v1.3")
 
     ctx.dispose()
 
     h.assert_eq[ILong](
-      SslAutoVersion().ilong(),
+      SSLAutoVersion().ilong(),
       ctx.get_max_proto_version(),
       "get_max_proto_version() on a disposed context should return "
-        + "SslAutoVersion")
+        + "SSLAutoVersion")
 
 class \nodoc\ iso _TestSSLContextGetMinProtoVersionOnValReceiver is UnitTest
   """
@@ -2155,7 +2155,7 @@ class \nodoc\ iso _TestSSLContextGetMinProtoVersionOnValReceiver is UnitTest
   require. A `fun ref` getter cannot be called on a `val` receiver, so this file
   stops compiling if that capability comes back.
 
-  `create` sets the minimum to `Tls1u2Version`, so the assertion is on a value
+  `create` sets the minimum to `TLS1u2Version`, so the assertion is on a value
   the getter had to read out of the context rather than on a default.
   """
   fun name(): String =>
@@ -2165,7 +2165,7 @@ class \nodoc\ iso _TestSSLContextGetMinProtoVersionOnValReceiver is UnitTest
     let ctx: SSLContext val = recover val SSLContext end
 
     h.assert_eq[ILong](
-      Tls1u2Version().ilong(),
+      TLS1u2Version().ilong(),
       ctx.get_min_proto_version(),
       "a val receiver should read back the minimum that create() set")
 
@@ -2177,8 +2177,8 @@ class \nodoc\ iso _TestSSLContextGetMaxProtoVersionOnValReceiver is UnitTest
   require. A `fun ref` getter cannot be called on a `val` receiver, so this file
   stops compiling if that capability comes back.
 
-  `create` leaves the maximum at `SslAutoVersion`, so this context sets it to
-  `Tls1u3Version` before it freezes. Without that, the assertion would hold
+  `create` leaves the maximum at `SSLAutoVersion`, so this context sets it to
+  `TLS1u3Version` before it freezes. Without that, the assertion would hold
   for a context whose maximum was never set.
   """
   fun name(): String =>
@@ -2187,11 +2187,11 @@ class \nodoc\ iso _TestSSLContextGetMaxProtoVersionOnValReceiver is UnitTest
   fun apply(h: TestHelper) ? =>
     let ctx: SSLContext val =
       recover val
-        SSLContext .> set_max_proto_version(Tls1u3Version())?
+        SSLContext .> set_max_proto_version(TLS1u3Version())?
       end
 
     h.assert_eq[ILong](
-      Tls1u3Version().ilong(),
+      TLS1u3Version().ilong(),
       ctx.get_max_proto_version(),
       "a val receiver should read back the maximum that was set")
 
@@ -2424,8 +2424,8 @@ class \nodoc\ iso _TestSSLContextAllowTlsV1u2 is UnitTest
                 FilePath(auth, "assets/key.pem"))?
             .> set_client_verify(false)
             .> set_server_verify(false)
-            .> set_min_proto_version(Tls1u2Version())?
-            .> set_max_proto_version(Tls1u2Version())?
+            .> set_min_proto_version(TLS1u2Version())?
+            .> set_max_proto_version(TLS1u2Version())?
           if disable then ctx.allow_tls_v1_2(false) end
           if reenable then ctx.allow_tls_v1_2(true) end
           ctx

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -80,8 +80,8 @@ class val SSLContext
       // Allow only newer ciphers. These raise only if `SSL_CTX_new` failed,
       // and a null context can never make a session, so the swallow is safe.
       try
-        set_min_proto_version(Tls1u2Version())?
-        set_max_proto_version(SslAutoVersion())?
+        set_min_proto_version(TLS1u2Version())?
+        set_max_proto_version(SSLAutoVersion())?
       end
     else
       compile_error "You must select an SSL version to use."
@@ -280,13 +280,13 @@ class val SSLContext
 
   fun ref set_min_proto_version(version: ULong) ? =>
     """
-    Set minimum protocol version. Set to SslAutoVersion, 0,
+    Set minimum protocol version. Set to SSLAutoVersion, 0,
     to automatically manage lowest version. Raises an error if the context has
     been disposed.
 
-    Supported versions: Ssl3Version, Tls1Version, Tls1u1Version,
-                        Tls1u2Version, Tls1u3Version, Dtls1Version,
-                        Dtls1u2Version
+    Supported versions: SSL3Version, TLS1Version, TLS1u1Version,
+                        TLS1u2Version, TLS1u3Version, DTLS1Version,
+                        DTLS1u2Version
     """
     if _ctx.is_null() then error end
 
@@ -299,27 +299,27 @@ class val SSLContext
 
   fun get_min_proto_version(): ILong =>
     """
-    Get minimum protocol version. Returns SslAutoVersion, 0,
+    Get minimum protocol version. Returns SSLAutoVersion, 0,
     when automatically managing lowest version. A disposed context returns
-    SslAutoVersion.
+    SSLAutoVersion.
 
-    Supported versions: Ssl3Version, Tls1Version, Tls1u1Version,
-                        Tls1u2Version, Tls1u3Version, Dtls1Version,
-                        Dtls1u2Version
+    Supported versions: SSL3Version, TLS1Version, TLS1u1Version,
+                        TLS1u2Version, TLS1u3Version, DTLS1Version,
+                        DTLS1u2Version
     """
-    if _ctx.is_null() then return SslAutoVersion().ilong() end
+    if _ctx.is_null() then return SSLAutoVersion().ilong() end
 
     @SSL_CTX_ctrl(_ctx, _SslCtrlGetMinProtoVersion(), 0, Pointer[None])
 
   fun ref set_max_proto_version(version: ULong) ? =>
     """
-    Set maximum protocol version. Set to SslAutoVersion, 0,
+    Set maximum protocol version. Set to SSLAutoVersion, 0,
     to automatically manage higest version. Raises an error if the context has
     been disposed.
 
-    Supported versions: Ssl3Version, Tls1Version, Tls1u1Version,
-                        Tls1u2Version, Tls1u3Version, Dtls1Version,
-                        Dtls1u2Version
+    Supported versions: SSL3Version, TLS1Version, TLS1u1Version,
+                        TLS1u2Version, TLS1u3Version, DTLS1Version,
+                        DTLS1u2Version
     """
     if _ctx.is_null() then error end
 
@@ -332,15 +332,15 @@ class val SSLContext
 
   fun get_max_proto_version(): ILong =>
     """
-    Get maximum protocol version. Returns SslAutoVersion, 0,
+    Get maximum protocol version. Returns SSLAutoVersion, 0,
     when automatically managing highest version. A disposed context returns
-    SslAutoVersion.
+    SSLAutoVersion.
 
-    Supported versions: Ssl3Version, Tls1Version, Tls1u1Version,
-                        Tls1u2Version, Tls1u3Version, Dtls1Version,
-                        Dtls1u2Version
+    Supported versions: SSL3Version, TLS1Version, TLS1u1Version,
+                        TLS1u2Version, TLS1u3Version, DTLS1Version,
+                        DTLS1u2Version
     """
-    if _ctx.is_null() then return SslAutoVersion().ilong() end
+    if _ctx.is_null() then return SSLAutoVersion().ilong() end
 
     @SSL_CTX_ctrl(_ctx, _SslCtrlGetMaxProtoVersion(), 0, Pointer[None])
 

--- a/ssl/net/ssl_versions.pony
+++ b/ssl/net/ssl_versions.pony
@@ -1,14 +1,14 @@
-primitive SslAutoVersion fun val apply(): ULong => 0x0
+primitive SSLAutoVersion fun val apply(): ULong => 0x0
 
-primitive Ssl3Version    fun val apply(): ULong => 0x300
-primitive Tls1Version    fun val apply(): ULong => 0x301
-primitive Tls1u1Version  fun val apply(): ULong => 0x302
-primitive Tls1u2Version  fun val apply(): ULong => 0x303
-primitive Tls1u3Version  fun val apply(): ULong => 0x304
-primitive Dtls1Version   fun val apply(): ULong => 0xFEFF
-primitive Dtls1u2Version fun val apply(): ULong => 0xFEFD
+primitive SSL3Version    fun val apply(): ULong => 0x300
+primitive TLS1Version    fun val apply(): ULong => 0x301
+primitive TLS1u1Version  fun val apply(): ULong => 0x302
+primitive TLS1u2Version  fun val apply(): ULong => 0x303
+primitive TLS1u3Version  fun val apply(): ULong => 0x304
+primitive DTLS1Version   fun val apply(): ULong => 0xFEFF
+primitive DTLS1u2Version fun val apply(): ULong => 0xFEFD
 
-primitive TlsMinVersion  fun val apply(): ULong => Tls1Version()
-primitive TlsMaxVersion  fun val apply(): ULong => Tls1u3Version()
-primitive DtlsMinVersion fun val apply(): ULong => Dtls1Version()
-primitive DtlsMaxVersion fun val apply(): ULong => Dtls1u2Version()
+primitive TLSMinVersion  fun val apply(): ULong => TLS1Version()
+primitive TLSMaxVersion  fun val apply(): ULong => TLS1u3Version()
+primitive DTLSMinVersion fun val apply(): ULong => DTLS1Version()
+primitive DTLSMaxVersion fun val apply(): ULong => DTLS1u2Version()


### PR DESCRIPTION
Every other type in the package spells the acronym out: `SSLContext`, `SSLConnection`, `SSLReady`, `ALPNProtocolResolver`. The twelve version primitives did not. pony-lint's `style/acronym-casing` rule flags eight of them; the four `Dtls` names are not flagged, because DTLS is not in the rule's dictionary, but are renamed anyway so the family reads alike.

The values and behavior are unchanged. This is the public rename split out of #67 so it carries its own CHANGELOG entry; the lint PR builds on it.

Part of #67
