### PR TITLE
Build the examples on Windows in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,6 +104,7 @@ jobs:
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command test 2>&1;
+          .\make.ps1 -Command examples 2>&1;
 
   test-arm64-windows-vs-ponyc-release:
     name: Windows arm64 (LibreSSL) with most recent ponyc release
@@ -132,3 +133,4 @@ jobs:
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command test 2>&1;
+          .\make.ps1 -Command examples 2>&1;

--- a/make.ps1
+++ b/make.ps1
@@ -1,5 +1,5 @@
 Param(
-  [Parameter(Position=0, HelpMessage="The action to take (build, test, install, package, clean).")]
+  [Parameter(Position=0, HelpMessage="The action to take (build, test, examples, install, package, clean).")]
   [string]
   $Command = 'build',
 
@@ -150,6 +150,27 @@ function BuildTest
   return $testFile
 }
 
+function BuildExamples
+{
+  $examplesDir = Join-Path -Path $rootDir -ChildPath "examples"
+
+  foreach ($example in (Get-ChildItem -Path $examplesDir -Directory))
+  {
+    $exampleName = $example.Name
+    Write-Host "Building example: $exampleName"
+
+    Write-Host "corral fetch"
+    $output = (corral fetch)
+    $output | ForEach-Object { Write-Host $_ }
+    if ($LastExitCode -ne 0) { throw "Error" }
+
+    Write-Host "corral run -- ponyc $configFlag $ponyArgs --output `"$buildDir`" `"$($example.FullName)`""
+    $output = (corral run -- ponyc $configFlag $ponyArgs --output "$buildDir" "$($example.FullName)")
+    $output | ForEach-Object { Write-Host $_ }
+    if ($LastExitCode -ne 0) { throw "Error building example $exampleName" }
+  }
+}
+
 switch ($Command.ToLower())
 {
   "build"
@@ -176,6 +197,16 @@ switch ($Command.ToLower())
     Write-Host "$testFile --sequential"
     & "$testFile" --sequential
     if ($LastExitCode -ne 0) { throw "Error" }
+    break
+  }
+
+  "examples"
+  {
+    if (-not (Test-Path "$buildDir"))
+    {
+      mkdir "$buildDir"
+    }
+    BuildExamples
     break
   }
 
@@ -239,6 +270,6 @@ switch ($Command.ToLower())
 
   default
   {
-    throw "Unknown command '$Command'; must be one of (build, test, install, package, clean, distclean)."
+    throw "Unknown command '$Command'; must be one of (build, test, examples, install, package, clean, distclean)."
   }
 }


### PR DESCRIPTION
The Linux CI builds the examples through `make test`, which depends on the `examples` target. `make.ps1` had no command to build examples, and the two Windows jobs only ran `make.ps1 -Command test`, so an example that stopped compiling on Windows would not have failed CI.

This adds a `BuildExamples` function and an `examples` command to `make.ps1`, and runs `make.ps1 -Command examples` in both Windows jobs after the test step. lori builds examples on every platform this way.
