### PR TITLE
Correct the docs on when constructing a Digest can fail

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -155,7 +155,7 @@ let hash = digest.final()?
 let mac = HmacSha256(key, message)?
 ```
 
-Constructing a `Digest` now raises if OpenSSL cannot allocate its context, rather than returning a digest that fails on every later call. When `HmacSha256` raises, reject the message. Do not fall back to a code of your own — a code you make up is one an attacker can send you.
+Constructing a `Digest` now raises if OpenSSL cannot allocate its context, rather than crashing. When `HmacSha256` raises, reject the message. Do not fall back to a code of your own — a code you make up is one an attacker can send you.
 
 ## Fix HmacSha256 returning an all-zero code when it fails
 
@@ -169,7 +169,7 @@ It was reachable with ordinary input: computing the code of an empty key and an 
 
 `final` returned a block of memory as the hash without checking that OpenSSL had written it, so a failed call returned whatever that memory held — a wrong hash, and a leak of whatever was last in it. Creating a digest crashed when OpenSSL could not allocate its working context.
 
-A digest now raises rather than returning a wrong hash, and one that could not be created reports it at the first `append` or `final` rather than crashing.
+A digest now raises rather than returning a wrong hash, and one that OpenSSL could not create raises when you construct it rather than crashing.
 
 ## Fix crypto functions truncating a length too large for an int
 

--- a/ssl/crypto/crypto.pony
+++ b/ssl/crypto/crypto.pony
@@ -14,12 +14,11 @@ A call here gives back a correct result or it raises. It never gives back an
 incorrect one, so there is no value to check for and no sentinel to compare
 against.
 
-`Digest.append`, `Digest.final`, `HmacSha256`, `Pbkdf2Sha256` and `RandBytes`
-are partial. They raise when OpenSSL could not do what was asked of it.
-`HmacSha256`, `Pbkdf2Sha256` and `RandBytes` also raise when a length you gave
-them is larger than the C `int` OpenSSL takes for it. Constructing a `Digest`
-cannot fail; a context OpenSSL would not give you surfaces at the first
-`append` or `final`.
+The `Digest` constructors, `Digest.append`, `Digest.final`, `HmacSha256`,
+`Pbkdf2Sha256` and `RandBytes` are partial. They raise when OpenSSL could not
+do what was asked of it. Constructing a `Digest` raises when OpenSSL cannot
+give it a context. `HmacSha256`, `Pbkdf2Sha256` and `RandBytes` also raise when
+a length you gave them is larger than the C `int` OpenSSL takes for it.
 
 The one-shot hash functions and `ConstantTimeCompare` cannot fail and are total.
 


### PR DESCRIPTION
PR #92 made the `Digest` constructors partial, so construction raises when OpenSSL cannot allocate the context. Three statements were left describing the old behavior.

`ssl/crypto/crypto.pony` said constructing a `Digest` cannot fail and that the failure surfaces at the first `append` or `final`, and it omitted the constructors from the list of partial functions.

`.release-notes/next-release.md` had two wrong clauses about the same thing. One said a digest that could not be created reports it at the first `append` or `final`; the other said construction now raises rather than returning a digest that fails on every later call. Before #92 a failed construction crashed, so both described a state that never shipped.

Closes #106
