### PR TITLE
Crash rather than swallow the impossible in ConstantTimeCompare

### DIFF
--- a/ssl/crypto/_unreachable.pony
+++ b/ssl/crypto/_unreachable.pony
@@ -1,0 +1,27 @@
+use @pony_os_stderr[Pointer[U8]]()
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @exit[None](status: I32)
+
+primitive _Unreachable
+  """
+  Panic for a code path that should be structurally impossible.
+
+  Print the file, line, and method to stderr, then exit. Use it in the `else`
+  of a `try`
+  whose error the surrounding code has already ruled out, so that if the
+  impossible ever does happen the program stops with a location instead of
+  carrying on with the error swallowed.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      "Unreachable code reached at %s:%lu in %s.%s\n".cstring(),
+      loc.file().cstring(),
+      loc.line(),
+      loc.type_name().cstring(),
+      loc.method_name().cstring())
+    @fprintf(
+      @pony_os_stderr(),
+      "Please open an issue at https://github.com/ponylang/ssl/issues\n"
+        .cstring())
+    @exit(1)

--- a/ssl/crypto/constant_time_compare.pony
+++ b/ssl/crypto/constant_time_compare.pony
@@ -14,16 +14,25 @@ primitive ConstantTimeCompare
   byte is read.
   """
   fun apply[S: ByteSeq box = ByteSeq box](xs: S, ys: S): Bool =>
+    _compare(xs, ys)
+
+  fun _compare(xs: ByteSeq box, ys: ByteSeq box): Bool =>
+    // Non-generic so it can call `_Unreachable`. That primitive takes a
+    // `SourceLoc` default of `__loc`, and `__loc` inside the generic `apply`
+    // does not compile.
     if xs.size() != ys.size() then
       false
     else
       var v = U8(0)
       var i: USize = 0
       while i < xs.size() do
+        // `i < xs.size()` bounds `xs(i)?`, and the size check above bounds
+        // `ys(i)?`, so neither read can raise; the `else` only satisfies the
+        // compiler.
         try
           v = v or (xs(i)? xor ys(i)?)
         else
-          return false
+          _Unreachable()
         end
         i = i + 1
       end


### PR DESCRIPTION
The compare loop reads `xs(i)?` and `ys(i)?`. The loop bounds the first, and the equal-size check bounds the second, so neither read can raise. The `try` caught the impossible error and returned `false` from it, which reports the two sequences unequal while hiding the bug that would have had to occur to reach it.

The `else` now calls `_Unreachable`, a new panic primitive for `ssl/crypto` that prints a location and exits. The comparison loop moved into a non-generic helper so it can call the primitive: `_Unreachable` takes a `SourceLoc` default of `__loc`, and `__loc` used inside the generic `apply` does not compile. The public signature of `apply` is unchanged.

Closes #107
