### PR TITLE
Allocate ssl/crypto output buffers one way

### DIFF
--- a/ssl/crypto/_test.pony
+++ b/ssl/crypto/_test.pony
@@ -2,6 +2,7 @@ use "pony_test"
 use "pony_check"
 
 use @memset[Pointer[None]](dst: Pointer[None], value: I32, n: USize)
+use @pony_ctx[Pointer[None]]()
 use @pony_triggergc[None](ctx: Pointer[None])
 
 actor \nodoc\ Main is TestList

--- a/ssl/crypto/crypto.pony
+++ b/ssl/crypto/crypto.pony
@@ -26,6 +26,3 @@ The one-shot hash functions and `ConstantTimeCompare` cannot fail and are total.
 When `HmacSha256` raises, reject the message. Do not compare it against a code
 of your own making — a code you invent is one an attacker can send you.
 """
-
-use @pony_ctx[Pointer[None]]()
-use @pony_alloc[Pointer[U8]](ctx: Pointer[None], size: USize)

--- a/ssl/crypto/digest.pony
+++ b/ssl/crypto/digest.pony
@@ -203,10 +203,7 @@ class Digest
       if _ctx.is_null() then error end
 
       let size = _digest_size
-      let digest =
-        recover String.from_cpointer(
-          @pony_alloc(@pony_ctx(), size), size)
-        end
+      let digest = recover Array[U8].init(0, size) end
 
       var rc: I32 = 0
       ifdef "openssl_3.0.x" or "openssl_4.0.x" then
@@ -231,12 +228,11 @@ class Digest
       end
       _ctx = Pointer[_EVPCTX]
 
-      // `@pony_alloc` does not zero the memory it returns, so a digest OpenSSL
-      // did not write holds whatever this actor freed last. Raising drops it
-      // rather than handing it back as a hash.
+      // On failure OpenSSL wrote nothing, so `digest` is still all zeros.
+      // Raise rather than hand a buffer OpenSSL did not fill back as a hash.
       if rc != 1 then error end
 
-      let h = (consume digest).array()
+      let h: Array[U8] val = consume digest
       _hash = h
       h
     end

--- a/ssl/crypto/hash_fn.pony
+++ b/ssl/crypto/hash_fn.pony
@@ -2,14 +2,14 @@ use "path:/usr/local/opt/libressl/lib" if osx and x86
 use "path:/opt/homebrew/opt/libressl/lib" if osx and arm
 use "lib:crypto"
 
-use @MD4[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])
-use @MD5[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])
-use @RIPEMD160[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])
-use @SHA1[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])
-use @SHA224[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])
-use @SHA256[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])
-use @SHA384[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])
-use @SHA512[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8])
+use @MD4[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8] tag)
+use @MD5[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8] tag)
+use @RIPEMD160[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8] tag)
+use @SHA1[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8] tag)
+use @SHA224[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8] tag)
+use @SHA256[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8] tag)
+use @SHA384[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8] tag)
+use @SHA512[Pointer[U8]](d: Pointer[U8] tag, n: USize, md: Pointer[U8] tag)
 
 use "format"
 
@@ -30,9 +30,9 @@ primitive MD4 is HashFn
   fun apply(input: ByteSeq): Array[U8] val =>
     recover
       let size: USize = 16
-      let digest = @pony_alloc(@pony_ctx(), size)
-      @MD4(input.cpointer(), input.size(), digest)
-      Array[U8].from_cpointer(digest, size)
+      let arr = Array[U8].init(0, size)
+      @MD4(input.cpointer(), input.size(), arr.cpointer())
+      arr
     end
 
 primitive MD5 is HashFn
@@ -42,9 +42,9 @@ primitive MD5 is HashFn
   fun apply(input: ByteSeq): Array[U8] val =>
     recover
       let size: USize = 16
-      let digest = @pony_alloc(@pony_ctx(), size)
-      @MD5(input.cpointer(), input.size(), digest)
-      Array[U8].from_cpointer(digest, size)
+      let arr = Array[U8].init(0, size)
+      @MD5(input.cpointer(), input.size(), arr.cpointer())
+      arr
     end
 
 primitive RIPEMD160 is HashFn
@@ -55,9 +55,9 @@ primitive RIPEMD160 is HashFn
   fun apply(input: ByteSeq): Array[U8] val =>
     recover
       let size: USize = 20
-      let digest = @pony_alloc(@pony_ctx(), size)
-      @RIPEMD160(input.cpointer(), input.size(), digest)
-      Array[U8].from_cpointer(digest, size)
+      let arr = Array[U8].init(0, size)
+      @RIPEMD160(input.cpointer(), input.size(), arr.cpointer())
+      arr
     end
 
 primitive SHA1 is HashFn
@@ -68,9 +68,9 @@ primitive SHA1 is HashFn
   fun apply(input: ByteSeq): Array[U8] val =>
     recover
       let size: USize = 20
-      let digest = @pony_alloc(@pony_ctx(), size)
-      @SHA1(input.cpointer(), input.size(), digest)
-      Array[U8].from_cpointer(digest, size)
+      let arr = Array[U8].init(0, size)
+      @SHA1(input.cpointer(), input.size(), arr.cpointer())
+      arr
     end
 
 primitive SHA224 is HashFn
@@ -81,9 +81,9 @@ primitive SHA224 is HashFn
   fun apply(input: ByteSeq): Array[U8] val =>
     recover
       let size: USize = 28
-      let digest = @pony_alloc(@pony_ctx(), size)
-      @SHA224(input.cpointer(), input.size(), digest)
-      Array[U8].from_cpointer(digest, size)
+      let arr = Array[U8].init(0, size)
+      @SHA224(input.cpointer(), input.size(), arr.cpointer())
+      arr
     end
 
 primitive SHA256 is HashFn
@@ -94,9 +94,9 @@ primitive SHA256 is HashFn
   fun apply(input: ByteSeq): Array[U8] val =>
     recover
       let size: USize = 32
-      let digest = @pony_alloc(@pony_ctx(), size)
-      @SHA256(input.cpointer(), input.size(), digest)
-      Array[U8].from_cpointer(digest, size)
+      let arr = Array[U8].init(0, size)
+      @SHA256(input.cpointer(), input.size(), arr.cpointer())
+      arr
     end
 
 primitive SHA384 is HashFn
@@ -107,9 +107,9 @@ primitive SHA384 is HashFn
   fun apply(input: ByteSeq): Array[U8] val =>
     recover
       let size: USize = 48
-      let digest = @pony_alloc(@pony_ctx(), size)
-      @SHA384(input.cpointer(), input.size(), digest)
-      Array[U8].from_cpointer(digest, size)
+      let arr = Array[U8].init(0, size)
+      @SHA384(input.cpointer(), input.size(), arr.cpointer())
+      arr
     end
 
 primitive SHA512 is HashFn
@@ -120,9 +120,9 @@ primitive SHA512 is HashFn
   fun apply(input: ByteSeq): Array[U8] val =>
     recover
       let size: USize = 64
-      let digest = @pony_alloc(@pony_ctx(), size)
-      @SHA512(input.cpointer(), input.size(), digest)
-      Array[U8].from_cpointer(digest, size)
+      let arr = Array[U8].init(0, size)
+      @SHA512(input.cpointer(), input.size(), arr.cpointer())
+      arr
     end
 
 primitive ToHexString


### PR DESCRIPTION
`ssl/crypto` allocated its output buffers two ways: `@pony_alloc` plus `from_cpointer` in the eight hash primitives and `Digest.final`, and `Array[U8].init` in `RandBytes`, `HmacSha256` and `Pbkdf2Sha256`. #77 established the two are equivalent to the garbage collector. This uses `Array.init` everywhere — the higher-level API, with no raw pointer to hand to `from_cpointer`.

The eight hash FFI declarations took `md: Pointer[U8]` to match `@pony_alloc`'s return. They take `Pointer[U8] tag` now, which is what `cpointer()` gives and what `RandBytes` and the others already use for an output buffer. With no production caller left, `@pony_alloc` is removed and `@pony_ctx` moves to `_test.pony`.

Closes #108
