### PR TITLE
Shuffle test order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ SOURCE_FILES := $(shell find $(SRC_DIR) -name \*.pony)
 test: unit-tests examples
 
 unit-tests: $(tests_binary)
-	$^ --exclude=integration --sequential
+	$^ --exclude=integration --sequential --shuffle
 
 test-one: $(tests_binary)
 	$^ --only="$(t)"

--- a/make.ps1
+++ b/make.ps1
@@ -194,8 +194,8 @@ switch ($Command.ToLower())
     }
 
     $testFile = (BuildTest)[-1]
-    Write-Host "$testFile --sequential"
-    & "$testFile" --sequential
+    Write-Host "$testFile --sequential --shuffle"
+    & "$testFile" --sequential --shuffle
     if ($LastExitCode -ne 0) { throw "Error" }
     break
   }


### PR DESCRIPTION
Add `--shuffle` to the test runs so tests execute in a randomized order, which surfaces hidden dependencies between tests.
