### PR TITLE
Stop disabling Windows Defender in CI

### DIFF
--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -12,8 +12,6 @@ jobs:
     name: Verify main against the latest ponyc on Windows
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Cache LibreSSL libs
         id: cache-libressl

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,8 +81,6 @@ jobs:
     name: Windows x86-64 (LibreSSL) with most recent ponyc release
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -110,8 +108,6 @@ jobs:
     name: Windows arm64 (LibreSSL) with most recent ponyc release
     runs-on: windows-11-arm
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Cache LibreSSL libs
         id: cache-libressl


### PR DESCRIPTION
Remove the "Disable Windows Defender" step from the Windows CI jobs. It doesn't speed the jobs up, and the step occasionally fails on some runners.
