### PR TITLE
Fix connections being closed after an unrelated SSL failure

### DIFF
--- a/.release-notes/clear-error-queue-before-ssl-io.md
+++ b/.release-notes/clear-error-queue-before-ssl-io.md
@@ -1,0 +1,3 @@
+## Fix connections being closed after an unrelated SSL failure
+
+A failed OpenSSL operation left error state on the scheduler thread that ran it. The next SSL session to read on that thread was treated as failed even when nothing was wrong with it, and its connection was closed. A rejected handshake was enough to start it, and so was a bad certificate path or an unusable cipher string given to `SSLContext`. A failed operation now affects only the session it happened on.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,12 @@ LibreSSL is mostly OpenSSL 1.1.x-compatible, but five differences need their own
 4. **`SSL_get_peer_certificate`** — LibreSSL keeps the pre-3.0.x name, not `SSL_get1_peer_certificate`.
 5. **`OPENSSL_INIT_new`/`OPENSSL_INIT_free`** — absent; init calls `OPENSSL_init_ssl` directly with no settings object.
 
+## The OpenSSL error queue
+
+The error queue belongs to the thread, not to the session. `SSL_get_error` reports what is on that queue, so it describes the call you are asking about only when the queue was empty before that call ran. Otherwise it reports an entry left by an earlier failure on the same thread, which may belong to a different session entirely.
+
+Every `SSL_*` I/O call gets `@ERR_clear_error()` immediately before it, whether or not its result reaches `SSL_get_error`. Some of them clear the queue themselves — `SSL_do_handshake` does — but that is undocumented and varies by backend, so don't work it out one call site at a time.
+
 ## Dispose and `_final`
 
 `dispose()` frees the OpenSSL handle and nulls the pointer field, so any later call hands OpenSSL a null. Most of the C functions dereference it without checking, and the ones that don't vary by backend — `SSL_CTX_ctrl` returns 0 for a null context on OpenSSL but dereferences it on LibreSSL. Check `is_null()` before calling into OpenSSL; don't count on a backend being forgiving.

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -7,6 +7,7 @@ use "net"
 use @memset[Pointer[None]](dst: Pointer[None], value: I32, n: USize)
 use @pony_ctx[Pointer[None]]()
 use @pony_triggergc[None](ctx: Pointer[None])
+use @ERR_peek_error[ULong]()
 
 actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
@@ -20,6 +21,8 @@ actor \nodoc\ Main is TestList
       _TestALPNProtocolListOffsetOfRoundtrip))
     test(_TestALPNStandardProtocolResolver)
     test(_TestSSLHandshakeInMemory)
+    test(_TestSSLFailedHandshakeDoesNotAffectLaterRead)
+    test(_TestSSLReadReportsGenuineError)
     test(_TestSSLDisposeBeforeHandshake)
     test(_TestSSLDisposeTwice)
     test(_TestSSLReadAfterDispose)
@@ -1240,6 +1243,118 @@ class \nodoc\ iso _TestSSLHandshakeInMemory is UnitTest
     | None =>
       h.fail("server read no application data")
     end
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLFailedHandshakeDoesNotAffectLaterRead is UnitTest
+  """
+  A handshake that fails on one session does not put a session that reads
+  afterwards into `SSLError`.
+
+  OpenSSL's error queue belongs to the thread, not to the session, and
+  `SSL_get_error` describes the call it is given only when that queue was empty
+  beforehand. A failed handshake leaves entries on it. A session that reads on
+  the same thread after that failure, with nothing to read, should stay
+  `SSLReady`. If it reports `SSLError` instead, a consumer branching on the
+  state closes a connection that is working.
+  """
+  fun name(): String =>
+    "net/ssl/SSL/failed_handshake_does_not_affect_later_read"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    // A handshake clears the error queue, so the failure has to be staged after
+    // the healthy pair handshakes, not before.
+    (let failed, let failed_peer) =
+      try
+        _TestSSLSessionPair.fresh(h)?
+      else
+        h.fail("could not create an SSL session pair")
+        client.dispose()
+        server.dispose()
+        return
+      end
+
+    // These bytes are not a valid TLS record, so the handshake fails.
+    failed.receive("NOT AN SSL HANDSHAKE\r\n")
+    h.assert_true(
+      failed.state() isnt SSLHandshake,
+      "non-handshake bytes should have taken the session out of SSLHandshake")
+
+    // With an empty queue this test cannot fail whatever `read` does, so check
+    // the failure left something on it.
+    h.assert_ne[ULong](
+      0,
+      @ERR_peek_error(),
+      "the failed handshake left nothing on the thread's error queue")
+
+    // Nothing was written to server, so this read has nothing to return.
+    match \exhaustive\ server.read()
+    | let data: Array[U8] iso =>
+      h.fail(
+        "a read with no data returned " + (consume data).size().string()
+          + " bytes")
+    | None => None
+    end
+    h.assert_true(
+      server.state() is SSLReady,
+      "a session with nothing to read should still be SSLReady")
+
+    failed.dispose()
+    failed_peer.dispose()
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReadReportsGenuineError is UnitTest
+  """
+  A read whose record will not decrypt reports `SSLError`.
+
+  Emptying the thread's error queue before each OpenSSL call must not cost a
+  session the errors that are its own. Flipping a byte of an encrypted record
+  breaks its authentication tag, which gives the read a real failure to report.
+  """
+  fun name(): String => "net/ssl/SSL/read_reports_genuine_error"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    try
+      client.write("hello")?
+      var record = client.send()?
+      let last = record.size() - 1
+      record(last)? = record(last)? xor 0xFF
+      server.receive(consume record)
+    else
+      h.fail("could not send a corrupted record")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    match \exhaustive\ server.read()
+    | let data: Array[U8] iso =>
+      h.fail(
+        "a corrupted record produced " + (consume data).size().string()
+          + " bytes")
+    | None => None
+    end
+    h.assert_true(
+      server.state() is SSLError,
+      "a record that will not decrypt should put the session in SSLError")
 
     client.dispose()
     server.dispose()

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -29,6 +29,7 @@ use @SSL_write[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: I32)
 use @BIO_read[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: I32)
 use @BIO_write[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: I32)
 use @SSL_get_error[I32](ssl: Pointer[_SSL], ret: I32)
+use @ERR_clear_error[None]()
 use @BIO_ctrl_pending[USize](bio: Pointer[_BIO] tag)
 use @SSL_has_pending[I32](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @SSL_get_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "libressl"
@@ -143,6 +144,7 @@ class SSL
       @SSL_set_accept_state(_ssl)
     else
       @SSL_set_connect_state(_ssl)
+      @ERR_clear_error()
       @SSL_do_handshake(_ssl)
     end
 
@@ -207,9 +209,11 @@ class SSL
       end
 
       _read_buf.undefined(offset + len)
+      @ERR_clear_error()
       @SSL_read(_ssl, _read_buf.cpointer(offset), len.i32())
     else
       _read_buf.undefined(offset + len)
+      @ERR_clear_error()
       let r =
         @SSL_read(_ssl, _read_buf.cpointer(offset), len.i32())
 
@@ -270,6 +274,7 @@ class SSL
     if _state isnt SSLReady then error end
 
     if data.size() > 0 then
+      @ERR_clear_error()
       @SSL_write(_ssl, data.cpointer(), data.size().i32())
     end
 
@@ -283,6 +288,7 @@ class SSL
     @BIO_write(_input, data.cpointer(), data.size().i32())
 
     if _state is SSLHandshake then
+      @ERR_clear_error()
       let r = @SSL_do_handshake(_ssl)
 
       if r > 0 then


### PR DESCRIPTION
`SSL_get_error` only describes the call it is asked about when the calling thread's OpenSSL error queue was empty before that call ran. Nothing cleared that queue, so one failed operation could put an unrelated healthy session into `SSLError` and get its connection closed. `@ERR_clear_error()` now runs immediately before each of the five SSL I/O calls.

Two tests. One checks that a session reading after an unrelated failed handshake stays `SSLReady`; it also asserts the failure actually left an entry on the queue, because without that the test cannot fail whatever `read` does. The other checks that a read whose record will not decrypt still reports `SSLError`, so clearing the queue cannot cost a session its own errors — before this, `_state = SSLError` could be deleted outright and the suite stayed green.

Measured on every backend the package supports. With the fix removed, the regression test fails on OpenSSL 1.1.1w, OpenSSL 3.6.2, LibreSSL 3.9.2 and LibreSSL 4.2.1, and passes on OpenSSL 4.0.0, which does not have the bug. The full suite passes on all five with the fix.

Closes #115
