### PR TITLE
Fix SSL sessions returning uninitialized memory

### DIFF
--- a/.release-notes/read-and-send-return-only-written-bytes.md
+++ b/.release-notes/read-and-send-return-only-written-bytes.md
@@ -1,0 +1,3 @@
+## Fix SSL sessions returning uninitialized memory
+
+`SSL.read` and `SSL.send` could return uninitialized memory. They no longer do.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,12 @@ Declare the Pony type that matches the C type in the header, not one that happen
 
 `ILong`/`ULong` track C's `long` — 32 bits on Windows and on 32-bit targets, 64 on 64-bit Unix — and `USize` tracks pointer-width `size_t`; neither stands in for `uint64_t`. Reaching for `ULong` because it is 64 bits on the platform in front of you passes 32 bits on every 32-bit build. A `Pointer[X]`'s element type never reaches the ABI, so a wrong one survives a null call but corrupts a later caller who passes `addressof` a real value. Public Pony signatures need not match the C types — convert at the call (`set_verify_depth` takes a `U32` and passes `depth.i32()`) — but a conversion that can wrap (a depth above `2^31` arriving negative) must be validated at the public boundary or called out in the docstring.
 
+## Buffers OpenSSL fills partway
+
+`SSL_read` and `BIO_read` write up to the length they are given and return the count they wrote. `Array.undefined` does not zero what it allocates. So a buffer sized to the length you asked for, and handed back whole, holds whatever the heap held past the count the call returned — out to the application from `read`, out to the peer from `send`. That is #123, where those bytes came back as plaintext the same session had already delivered to the same caller.
+
+Set the size from the call's return on every path out, and treat a return of zero or less as no bytes written rather than as a count.
+
 ## Conventions
 
 - `\nodoc\` on test classes, actors, and primitives.

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -23,6 +23,10 @@ actor \nodoc\ Main is TestList
     test(_TestSSLHandshakeInMemory)
     test(_TestSSLFailedHandshakeDoesNotAffectLaterRead)
     test(_TestSSLReadReportsGenuineError)
+    test(_TestSSLReadAfterErrorReturnsOnlyDecryptedBytes)
+    test(_TestSSLReadWithBufferedBytes)
+    test(_TestSSLReadNoExpectAfterError)
+    test(_TestSSLReadPendingExceedsExpect)
     test(_TestSSLDisposeBeforeHandshake)
     test(_TestSSLDisposeTwice)
     test(_TestSSLReadAfterDispose)
@@ -1128,6 +1132,23 @@ primitive \nodoc\ _TestSSLTransfer
       receiver.receive(sender.send()?)
     end
 
+primitive \nodoc\ _TestSSLCorruptRecord
+  fun val apply(sender: SSL, receiver: SSL, payload: ByteSeq) ? =>
+    """
+    Write `payload` on the sender and hand the receiver the resulting
+    ciphertext with its last byte flipped, which breaks the authentication tag
+    of the record that byte belongs to.
+    """
+    sender.write(payload)?
+    var record = sender.send()?
+    let last = record.size() - 1
+    record(last)? = record(last)? xor 0xFF
+    receiver.receive(consume record)
+    // `send` returns one buffer, and a payload large enough to span records
+    // leaves the rest queued. Hand those over too, so the receiver gets
+    // everything the sender wrote.
+    _TestSSLTransfer(sender, receiver)?
+
 primitive \nodoc\ _TestSSLSessionPair
   fun val apply(h: TestHelper): (SSL, SSL) ? =>
     """
@@ -1333,11 +1354,7 @@ class \nodoc\ iso _TestSSLReadReportsGenuineError is UnitTest
       end
 
     try
-      client.write("hello")?
-      var record = client.send()?
-      let last = record.size() - 1
-      record(last)? = record(last)? xor 0xFF
-      server.receive(consume record)
+      _TestSSLCorruptRecord(client, server, "hello")?
     else
       h.fail("could not send a corrupted record")
       client.dispose()
@@ -1355,6 +1372,257 @@ class \nodoc\ iso _TestSSLReadReportsGenuineError is UnitTest
     h.assert_true(
       server.state() is SSLError,
       "a record that will not decrypt should put the session in SSLError")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReadAfterErrorReturnsOnlyDecryptedBytes is UnitTest
+  """
+  A read that fails partway through an `expect` block does not hand back the
+  part of the block no decrypt ever wrote.
+
+  Fifty bytes and a read of a hundred leave half a block buffered. The read
+  that meets the broken record fails with those fifty still there, so a read
+  of a hundred must return `None` and a read of fifty must return the fifty.
+  """
+  fun name(): String =>
+    "net/ssl/SSL.read/after_error_returns_only_decrypted_bytes"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    // Half of the hundred the reads below request, so the first of them
+    // buffers these bytes and returns nothing.
+    try
+      client.write(recover val Array[U8].init('A', 50) end)?
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("client could not send application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    match \exhaustive\ server.read(100)
+    | let data: Array[U8] iso =>
+      h.fail(
+        "50 bytes satisfied a read of 100 and produced "
+          + (consume data).size().string() + " bytes")
+      client.dispose()
+      server.dispose()
+      return
+    | None => None
+    end
+
+    try
+      _TestSSLCorruptRecord(
+        client, server, recover val Array[U8].init('B', 50) end)?
+    else
+      h.fail("could not send a corrupted record")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    match \exhaustive\ server.read(100)
+    | let data: Array[U8] iso =>
+      h.fail(
+        "a corrupted record produced " + (consume data).size().string()
+          + " bytes")
+    | None => None
+    end
+    h.assert_true(
+      server.state() is SSLError,
+      "a record that will not decrypt should put the session in SSLError")
+
+    match \exhaustive\ server.read(100)
+    | let data: Array[U8] iso =>
+      h.fail(
+        "a read of 100 returned " + (consume data).size().string()
+          + " bytes with only 50 decrypted")
+    | None => None
+    end
+
+    // A read with no `expect` decrypts before it hands anything over, so on a
+    // failed session it returns `None` and leaves the fifty where they are.
+    match \exhaustive\ server.read()
+    | let data: Array[U8] iso =>
+      h.fail(
+        "a read with no expect returned " + (consume data).size().string()
+          + " bytes from a failed session")
+    | None => None
+    end
+
+    match \exhaustive\ server.read(50)
+    | let data: Array[U8] iso =>
+      h.assert_array_eq[U8](
+        recover val Array[U8].init('A', 50) end,
+        consume data,
+        "a read of 50 returned something other than the 50 decrypted bytes")
+    | None =>
+      h.fail("a read of 50 returned none of the 50 bytes that were decrypted")
+    end
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReadWithBufferedBytes is UnitTest
+  """
+  A read with no `expect` returns `None` when it decrypts nothing, whatever is
+  already buffered. A read with an `expect` at or below how many are buffered
+  returns all of them, not `expect` of them.
+  """
+  fun name(): String => "net/ssl/SSL.read/with_buffered_bytes"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    try
+      client.write(recover val Array[U8].init('A', 50) end)?
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("client could not send application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    match \exhaustive\ server.read(100)
+    | let data: Array[U8] iso =>
+      h.fail(
+        "50 bytes satisfied a read of 100 and produced "
+          + (consume data).size().string() + " bytes")
+      client.dispose()
+      server.dispose()
+      return
+    | None => None
+    end
+
+    h.assert_true(
+      server.state() is SSLReady,
+      "the session should still be SSLReady")
+
+    match \exhaustive\ server.read()
+    | let data: Array[U8] iso =>
+      h.fail(
+        "a read with no expect returned " + (consume data).size().string()
+          + " bytes from a call that decrypted nothing")
+    | None => None
+    end
+
+    match \exhaustive\ server.read(20)
+    | let data: Array[U8] iso =>
+      h.assert_eq[USize](
+        50,
+        (consume data).size(),
+        "a read of 20 against 50 buffered bytes returned")
+    | None => h.fail("a read of 20 returned None with 50 bytes buffered")
+    end
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReadNoExpectAfterError is UnitTest
+  """
+  A read with no `expect` on a failed session returns `None` and leaves nothing
+  behind that a later read hands out.
+
+  The read of one byte at the end returns whatever is buffered, so it reports
+  what the failed read left.
+  """
+  fun name(): String => "net/ssl/SSL.read/no_expect_after_error"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    try
+      _TestSSLCorruptRecord(client, server, "hello")?
+    else
+      h.fail("could not send a corrupted record")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    match \exhaustive\ server.read()
+    | let data: Array[U8] iso =>
+      h.fail(
+        "a corrupted record produced " + (consume data).size().string()
+          + " bytes")
+    | None => None
+    end
+
+    // A read of one byte returns the buffer whole if the failed read left
+    // anything in it, so a returned array gives the size that was left.
+    match \exhaustive\ server.read(1)
+    | let data: Array[U8] iso =>
+      h.fail(
+        "a read of 1 returned " + (consume data).size().string()
+          + " bytes with none decrypted")
+    | None => None
+    end
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReadPendingExceedsExpect is UnitTest
+  """
+  A read that draws on more bytes than it requested takes only what it
+  requested.
+
+  Fifty bytes are written at once and no ciphertext moves between the two
+  reads, so the second draws on bytes OpenSSL had already decrypted.
+  """
+  fun name(): String => "net/ssl/SSL.read/pending_exceeds_expect"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    try
+      client.write(recover val Array[U8].init('A', 50) end)?
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("client could not send application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    match \exhaustive\ server.read(20)
+    | let data: Array[U8] iso =>
+      h.assert_eq[USize](20, (consume data).size(), "read(20) returned")
+    | None => h.fail("read(20) returned None with 50 bytes available")
+    end
+
+    match \exhaustive\ server.read(10)
+    | let data: Array[U8] iso =>
+      h.assert_eq[USize](10, (consume data).size(), "read(10) returned")
+    | None => h.fail("read(10) returned None with 30 bytes pending")
+    end
 
     client.dispose()
     server.dispose()
@@ -1579,7 +1847,8 @@ class \nodoc\ iso _TestSSLSendAfterDispose is UnitTest
   `send` on a disposed session raises an error instead of reading a freed BIO.
 
   The session has encrypted bytes waiting when it is disposed, so the error
-  here is the disposed check and not the empty BIO check.
+  here comes from the disposed check and not from any of the other reasons
+  `send` raises.
   """
   fun name(): String => "net/ssl/SSL.send/after_dispose"
 

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -39,6 +39,15 @@ primitive _SSL
 primitive _BIO
 primitive _BIOMethod
 
+primitive _SSLErrorCode
+  """
+  `SSL_get_error` results, from `openssl/ssl.h`.
+  """
+  fun ssl(): I32 => 1
+  fun want_read(): I32 => 2
+  fun syscall(): I32 => 5
+  fun zero_return(): I32 => 6
+
 primitive SSLHandshake
   """
   The session is still handshaking.
@@ -179,8 +188,8 @@ class SSL
   fun ref read(expect: USize = 0): (Array[U8] iso^ | None) =>
     """
     Returns unencrypted bytes to be passed to the application. If `expect` is
-    non-zero, the number of bytes returned will be exactly `expect`. If no data
-    (or less than `expect` bytes) is available, this returns None. A disposed
+    non-zero, this returns None until at least `expect` bytes are available,
+    then returns everything it holds, which is at least `expect`. A disposed
     session returns None.
     """
     if _ssl.is_null() then return None end
@@ -198,39 +207,28 @@ class SSL
         1024
       end
 
-    let max = if expect > 0 then expect - offset else USize.max_value() end
     let pending = @SSL_pending(_ssl).usize()
 
     if pending > 0 then
-      if expect > 0 then
-        len = len.min(pending)
-      else
-        len = pending
-      end
+      len = if expect > 0 then len.min(pending) else pending end
+    end
 
-      _read_buf.undefined(offset + len)
-      @ERR_clear_error()
-      @SSL_read(_ssl, _read_buf.cpointer(offset), len.i32())
-    else
-      _read_buf.undefined(offset + len)
-      @ERR_clear_error()
-      let r =
-        @SSL_read(_ssl, _read_buf.cpointer(offset), len.i32())
+    _read_buf.undefined(offset + len)
+    @ERR_clear_error()
+    let r = @SSL_read(_ssl, _read_buf.cpointer(offset), len.i32())
 
-      if r <= 0 then
-        match @SSL_get_error(_ssl, r)
-        | 1 | 5 | 6 =>
-          _state = SSLError
-          return None
-        | 2 =>
-          // SSL buffer has more data but it is not yet decoded (or something)
-          _read_buf.truncate(offset)
-          return None
-        end
+    let filled = if r > 0 then r.usize() else 0 end
+    _read_buf.truncate(offset + filled)
 
-        _read_buf.truncate(offset)
-      else
-        _read_buf.truncate(offset + r.usize())
+    if r <= 0 then
+      match @SSL_get_error(_ssl, r)
+      | _SSLErrorCode.ssl()
+      | _SSLErrorCode.syscall()
+      | _SSLErrorCode.zero_return() =>
+        _state = SSLError
+        return None
+      | _SSLErrorCode.want_read() =>
+        return None
       end
     end
 
@@ -295,8 +293,9 @@ class SSL
         _verify_hostname()
       else
         match @SSL_get_error(_ssl, r)
-        | 1 => _state = SSLAuthFail
-        | 5 | 6 => _state = SSLError
+        | _SSLErrorCode.ssl() => _state = SSLAuthFail
+        | _SSLErrorCode.syscall() | _SSLErrorCode.zero_return() =>
+          _state = SSLError
         end
       end
     end
@@ -321,7 +320,9 @@ class SSL
     if len == 0 then error end
 
     let buf = recover Array[U8] .> undefined(len) end
-    @BIO_read(_output, buf.cpointer(), buf.size().i32())
+    let r = @BIO_read(_output, buf.cpointer(), buf.size().i32())
+    if r <= 0 then error end
+    buf.truncate(r.usize())
     buf
 
   fun ref dispose() =>


### PR DESCRIPTION
`SSL.read` sized its buffer from the length it was about to request, then returned that size as the number of bytes decrypted. On two of its exits those numbers did not match, and the caller got uninitialized heap back as application data. `SSL.send` had the same defect against `BIO_read` and gets the same fix.

`read` also had two `SSL_read` call sites, one that truncated the buffer on some exits and one that truncated on none. It has one call site and one truncate now, so a path that skips the truncate can't be written.

`SSL_get_error` results were matched as bare integers in `read` and `receive`; they are named values on a `_SSLErrorCode` primitive now. The dead `max` binding #117 names was part of the sizing logic being rewritten, so it comes out here too.

The `if pending > 0` clamp is an allocation bound now, not a correctness guard. Shrinking `len` to `SSL_pending`'s count used to be what kept the returned size right. The size comes off `SSL_read`'s return on every path now, so the clamp only bounds the allocation. Delete the whole block and every test still passes with every returned byte correct.

Reaching the two new lines in `send` takes two gibibytes or more of queued ciphertext, the case #121 narrows to. Both lines can be deleted with the full suite green.

The missing `else` on the `SSL_get_error` match, #120, is now reachable from a path that could not reach it before. Previously only the `SSL_pending == 0` path reached it.

Five open issues cite `ssl/net/ssl.pony` line numbers we move here: #118, #119, #120, #121, #122. Renumbering isn't enough for #121. It describes `read` as having two `SSL_read` call sites and says `send` returns uninitialized heap to the peer, and neither holds after this.

Closes #123
Closes #117
