### PR TITLE
Fix handshake failures being reported as authentication failures

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -6,3 +6,24 @@ A failed OpenSSL operation left error state on the scheduler thread that ran it.
 
 `SSL.read` and `SSL.send` could return uninitialized memory. They no longer do.
 
+## Fix handshake failures being reported as authentication failures
+
+`SSLAuthFail` was documented as the peer's certificate failing to verify, but a session reported it after failures that had nothing to do with authenticating the peer: a peer that sent something other than TLS to a TLS port, or two peers with no protocol version in common.
+
+A session now reports `SSLAuthFail` when it required a certificate from its peer and did not get an acceptable one:
+
+- the peer's certificate chain did not verify
+- the peer's certificate was not valid for the hostname the session was created with
+- the peer presented no certificate at all
+
+Every other failure reports `SSLError`, including a peer that does not speak TLS, a peer that shares no protocol version with the session, and a peer that rejects the certificate the session presented.
+
+## Report SSLAuthFail only for a peer certificate the session would not accept
+
+Three things that reported `SSLAuthFail` before this release report `SSLError` now, and no compile error will point you at them.
+
+A peer that presents a certificate it cannot prove it holds — which is what an impersonator using a copy of a public certificate produces — and a peer whose certificate will not parse are the first two. There is no way to tell either of them from any other `SSLError` through the session state.
+
+A session created with verification off is the third. That includes a server built without `set_server_verify(true)`, which is the default: it sends no certificate request, so it has no peer identity to reject.
+
+If you wrap a protocol in `SSLConnection`, what changes is whether `auth_failed` runs before `closed`. `SSLConnection` calls `auth_failed` for `SSLAuthFail` and nothing for `SSLError`, and closes the connection on both, so a protocol that used to get `auth_failed` for one of these now gets `closed` on its own. A `closed` with no `connected` or `accepted` before it means the handshake failed. The reverse does not hold: under TLS 1.3 a session can finish its own side of the handshake before its peer's rejection reaches it, so a peer that rejected the connection can still produce `connected` and then `closed`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ The error queue belongs to the thread, not to the session. `SSL_get_error` repor
 
 Every `SSL_*` I/O call gets `@ERR_clear_error()` immediately before it, whether or not its result reaches `SSL_get_error`. Some of them clear the queue themselves — `SSL_do_handshake` does — but that is undocumented and varies by backend, so don't work it out one call site at a time.
 
+Reading an entry off that queue goes wrong two ways. Comparing a whole word against a constant looks exact and is not: OpenSSL 1.1.x and LibreSSL pack a function code into the same word, and it is neither zero nor fixed — LibreSSL gives library 20 with reason 199 as `0x14FFF0C7` after negotiating TLS 1.3 and `0x140360C7` after TLS 1.2. And the entry you want is not always the first one, because a failure inside libcrypto puts its own entry on the queue before libssl puts one there. Take the library and the reason apart, and look at every entry rather than the head.
+
 ## Dispose and `_final`
 
 `dispose()` frees the OpenSSL handle and nulls the pointer field, so any later call hands OpenSSL a null. Most of the C functions dereference it without checking, and the ones that don't vary by backend — `SSL_CTX_ctrl` returns 0 for a null context on OpenSSL but dereferences it on LibreSSL. Check `is_null()` before calling into OpenSSL; don't count on a backend being forgiving.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ All notable changes to this project will be documented in this file. This projec
 
 - Fix connections being closed after an unrelated SSL failure ([PR #116](https://github.com/ponylang/ssl/pull/116))
 - Fix SSL sessions returning uninitialized memory ([PR #124](https://github.com/ponylang/ssl/pull/124))
+- Fix handshake failures being reported as authentication failures ([PR #126](https://github.com/ponylang/ssl/pull/126))
 
 ### Added
 
 
 ### Changed
 
+- Report SSLAuthFail only for a peer certificate the session would not accept ([PR #126](https://github.com/ponylang/ssl/pull/126))
 
 ## [3.0.0] - 2026-07-10
 

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -21,6 +21,16 @@ actor \nodoc\ Main is TestList
       _TestALPNProtocolListOffsetOfRoundtrip))
     test(_TestALPNStandardProtocolResolver)
     test(_TestSSLHandshakeInMemory)
+    test(_TestSSLReceiveNonTLSBytes)
+    test(_TestSSLReceiveUntrustedChain)
+    test(_TestSSLReceivePeerRejectedOurCert)
+    test(_TestSSLReceiveHostnameMismatch)
+    test(_TestSSLReceiveNoSharedVersion)
+    test(_TestSSLReceiveNoPeerCertificate)
+    test(_TestSSLReceiveVerifyOffNeverAuthFails)
+    test(_TestSSLReceiveUnprovenCertificate)
+    test(_TestSSLReceiveUntrustedClientChain)
+    test(_TestERRCodeFields)
     test(_TestSSLFailedHandshakeDoesNotAffectLaterRead)
     test(_TestSSLReadReportsGenuineError)
     test(_TestSSLReadAfterErrorReturnsOnlyDecryptedBytes)
@@ -67,6 +77,7 @@ actor \nodoc\ Main is TestList
     test(_TestTCPSSLClientVerifyFalseWithHostname)
     test(_TestTCPSSLPeerCertificateVerify)
     test(_TestTCPSSLPeerCertificateHostnameMismatch)
+    test(_TestTCPSSLNonTLSPeerDoesNotAuthFail)
     ifdef windows then
       test(_TestWindowsLoadRootCertificates)
     else
@@ -300,7 +311,7 @@ class \nodoc\ iso _TestTCPSSLExpect is UnitTest
 
     (let ssl_client, let ssl_server) =
       try
-        _TestSSLContext(h)?
+        _TestSSLDefaultSessions(h)?
       else
         h.fail("ssl stuff failed")
         return
@@ -323,7 +334,7 @@ class \nodoc\ iso _TestTCPSSLWritev is UnitTest
 
     (let ssl_client, let ssl_server) =
       try
-        _TestSSLContext(h)?
+        _TestSSLDefaultSessions(h)?
       else
         h.fail("ssl stuff failed")
         return
@@ -358,7 +369,7 @@ class \nodoc\ iso _TestTCPSSLMute is UnitTest
 
     (let ssl_client, let ssl_server) =
       try
-        _TestSSLContext(h)?
+        _TestSSLDefaultSessions(h)?
       else
         h.fail("ssl stuff failed")
         return
@@ -397,7 +408,7 @@ class \nodoc\ iso _TestTCPSSLUnmute is UnitTest
 
     (let ssl_client, let ssl_server) =
       try
-        _TestSSLContext(h)?
+        _TestSSLDefaultSessions(h)?
       else
         h.fail("ssl stuff failed")
         return
@@ -683,6 +694,66 @@ class \nodoc\ _TestTCPSSLPeerCertificateHostnameMismatchServerNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("server connect failed")
 
+class \nodoc\ iso _TestTCPSSLNonTLSPeerDoesNotAuthFail is UnitTest
+  """
+  A peer that sends bytes that are not TLS does not reach the wrapped
+  protocol's `auth_failed`.
+
+  `SSLConnection` calls `auth_failed` on `SSLAuthFail`, so a session that
+  reports that state for a peer speaking something other than TLS tells the
+  application its authentication failed. The server here is a plain
+  `TCPConnectionNotify` with no SSL at all, answering a TLS client with HTTP.
+  """
+  fun name(): String => "net/TCPSSL.non_tls_peer_does_not_auth_fail"
+  fun exclusion_group(): String => "network"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("client closed")
+
+    let ssl_client =
+      try
+        _TestSSLContext(h where authority = true, client_verify = true)?
+          .client("localhost")?
+      else
+        h.fail("failed getting ssl client session")
+        return
+      end
+
+    _TestTCP(h)(
+      SSLConnection(_TestTCPNonTLSPeerClientNotify(h), consume ssl_client),
+      _TestTCPNonTLSPeerServerNotify(h))
+
+class \nodoc\ _TestTCPNonTLSPeerClientNotify is TCPConnectionNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref connected(conn: TCPConnection ref) =>
+    _h.fail("the handshake completed against a peer that did not speak TLS")
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    _h.fail_action("client connect failed")
+
+  fun ref auth_failed(conn: TCPConnection ref) =>
+    _h.fail("auth_failed fired for a peer that did not speak TLS")
+
+  fun ref closed(conn: TCPConnection ref) =>
+    _h.complete_action("client closed")
+    _h.complete(true)
+
+class \nodoc\ _TestTCPNonTLSPeerServerNotify is TCPConnectionNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref accepted(conn: TCPConnection ref) =>
+    conn.write("HTTP/1.1 400 Bad Request\r\n\r\n")
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    _h.fail_action("server connect failed")
+
 class \nodoc\ iso _TestTCPSSLThrottle is UnitTest
   """
   Test that when we experience backpressure when sending that the `throttled`
@@ -709,7 +780,7 @@ class \nodoc\ iso _TestTCPSSLThrottle is UnitTest
 
     (let ssl_client, let ssl_server) =
       try
-        _TestSSLContext(h)?
+        _TestSSLDefaultSessions(h)?
       else
         h.fail("ssl stuff failed")
         return
@@ -1086,24 +1157,19 @@ class \nodoc\ _TestTCPUnmuteReceiveNotify is TCPConnectionNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("receiver connect failed")
 
-primitive \nodoc\ _TestSSLContext
+primitive \nodoc\ _TestSSLDefaultSessions
   fun val apply(h: TestHelper): (SSL iso^, SSL iso^) ? =>
+    """
+    A client and a server session from a context that trusts the test
+    certificate, presents it, and verifies neither side.
+    """
     let sslctx =
-      try
-        let auth = FileAuth(h.env.root)
-        recover val
-          SSLContext
-            .> set_authority(FilePath(auth, "assets/cert.pem"))?
-            .> set_cert(
-                FilePath(auth, "assets/cert.pem"),
-                FilePath(auth, "assets/key.pem"))?
-            .> set_client_verify(false)
-            .> set_server_verify(false)
-        end
-      else
-        h.fail("set_cert failed")
-        error
-      end
+      _TestSSLContext(
+        h
+        where cert = true,
+          authority = true,
+          client_verify = false,
+          server_verify = false)?
 
     let ssl_client =
       try
@@ -1149,6 +1215,50 @@ primitive \nodoc\ _TestSSLCorruptRecord
     // everything the sender wrote.
     _TestSSLTransfer(sender, receiver)?
 
+primitive \nodoc\ _TestSSLContext
+  fun val apply(
+    h: TestHelper,
+    cert: Bool = false,
+    authority: Bool = false,
+    client_verify: Bool = true,
+    server_verify: Bool = false,
+    min_proto: (ULong | None) = None,
+    max_proto: (ULong | None) = None)
+    : SSLContext val ?
+  =>
+    """
+    A context with no certificate and no authority until asked for them. Every
+    setting is a parameter, so a test that turns on what it is testing shows it
+    at the call site.
+    """
+    let auth = FileAuth(h.env.root)
+
+    try
+      recover val
+        let ctx: SSLContext ref = SSLContext
+        if cert then
+          ctx.set_cert(
+            FilePath(auth, "assets/cert.pem"),
+            FilePath(auth, "assets/key.pem"))?
+        end
+        if authority then
+          ctx.set_authority(FilePath(auth, "assets/cert.pem"))?
+        end
+        ctx.set_client_verify(client_verify)
+        ctx.set_server_verify(server_verify)
+        match min_proto
+        | let v: ULong => ctx.set_min_proto_version(v)?
+        end
+        match max_proto
+        | let v: ULong => ctx.set_max_proto_version(v)?
+        end
+        ctx
+      end
+    else
+      h.fail("ssl context setup failed")
+      error
+    end
+
 primitive \nodoc\ _TestSSLSessionPair
   fun val apply(h: TestHelper): (SSL, SSL) ? =>
     """
@@ -1164,7 +1274,7 @@ primitive \nodoc\ _TestSSLSessionPair
     A client and a server session from the standard test context, before any
     handshake. Both are in `SSLHandshake`.
     """
-    (let client_session, let server_session) = _TestSSLContext(h)?
+    (let client_session, let server_session) = _TestSSLDefaultSessions(h)?
     let client: SSL = consume client_session
     let server: SSL = consume server_session
     (client, server)
@@ -1191,31 +1301,96 @@ primitive \nodoc\ _TestSSLSessionPair
     _handshake(h, client, server)?
     (client, server)
 
+  fun val _fresh_from(
+    h: TestHelper,
+    client_ctx: SSLContext val,
+    server_ctx: SSLContext val,
+    hostname: String = "")
+    : (SSL, SSL) ?
+  =>
+    """
+    A client session from `client_ctx` and a server session from `server_ctx`,
+    before any handshake. Both are in `SSLHandshake`.
+    """
+    let client: SSL =
+      try
+        client_ctx.client(hostname)?
+      else
+        h.fail("failed getting ssl client session")
+        error
+      end
+    let server: SSL =
+      try
+        server_ctx.server()?
+      else
+        h.fail("failed getting ssl server session")
+        client.dispose()
+        error
+      end
+    (client, server)
+
+  fun val attempt(
+    h: TestHelper,
+    client_ctx: SSLContext val,
+    server_ctx: SSLContext val,
+    hostname: String = "")
+    : (SSL, SSL) ?
+  =>
+    """
+    A client session from `client_ctx` and a server session from `server_ctx`,
+    handed each other's bytes until neither is still handshaking or the round
+    cap stops it. A handshake that does not complete is a result to assert on
+    rather than a reason to fail the test, which is what separates this from
+    `apply`. Assert on the state you expect; a session left in `SSLHandshake`
+    fails that assertion.
+    """
+    (let client, let server) = _fresh_from(h, client_ctx, server_ctx, hostname)?
+    _pump(client, server)?
+    (client, server)
+
+  fun val _pump(client: SSL, server: SSL): USize ? =>
+    """
+    Hand each side's outgoing bytes to the other until neither is still
+    handshaking, and return how many rounds that took. Stops at `_max_rounds`
+    whether or not the sessions settled, so a caller that needs them settled
+    has to check.
+    """
+    var rounds: USize = 0
+
+    while
+      ((client.state() is SSLHandshake) or (server.state() is SSLHandshake))
+        and (rounds < _max_rounds())
+    do
+      rounds = rounds + 1
+      // Both directions run every round, so a side that has already failed
+      // still hands its alert to the other.
+      _TestSSLTransfer(client, server)?
+      _TestSSLTransfer(server, client)?
+    end
+
+    rounds
+
+  fun val _max_rounds(): USize =>
+    """
+    How many rounds a handshake takes depends on the TLS version and the
+    backend, so this is a backstop against a session that never settles, not a
+    count anything should rely on.
+    """
+    20
+
   fun val _handshake(h: TestHelper, client: SSL, server: SSL) ? =>
     """
     Drive a handshake to completion by handing each side's outgoing bytes
     straight to the other. Reports the reason and raises an error if the
     handshake does not finish.
     """
-    // How many rounds a handshake takes depends on the TLS version and the
-    // backend, so this is a backstop against a session that never settles,
-    // not a count anything should rely on.
-    let max_rounds: USize = 20
-    var rounds: USize = 0
+    let rounds = _pump(client, server)?
 
-    while
-      (client.state() is SSLHandshake) or (server.state() is SSLHandshake)
-    do
-      if rounds == max_rounds then
-        h.fail(
-          "in memory SSL handshake did not finish in "
-            + max_rounds.string() + " rounds")
-        error
-      end
-      rounds = rounds + 1
-
-      _TestSSLTransfer(client, server)?
-      _TestSSLTransfer(server, client)?
+    if (client.state() is SSLHandshake) or (server.state() is SSLHandshake) then
+      h.fail(
+        "in memory SSL handshake did not finish in " + rounds.string()
+          + " rounds")
+      error
     end
 
     if (client.state() isnt SSLReady) or (server.state() isnt SSLReady) then
@@ -1268,6 +1443,391 @@ class \nodoc\ iso _TestSSLHandshakeInMemory is UnitTest
     client.dispose()
     server.dispose()
 
+class \nodoc\ iso _TestSSLReceiveNonTLSBytes is UnitTest
+  """
+  A verifying session handed bytes that are not a TLS record reports
+  `SSLError`.
+
+  Those bytes fail the handshake at the SSL layer, which is where a chain that
+  will not verify fails too. Reporting `SSLAuthFail` for them tells a caller
+  the peer could not be authenticated when nothing about the peer's identity
+  was in question.
+  """
+  fun name(): String => "net/ssl/SSL.receive/non_tls_bytes"
+
+  fun apply(h: TestHelper) =>
+    let client =
+      try
+        _TestSSLContext(h where authority = true, client_verify = true)?
+          .client()?
+      else
+        h.fail("could not create a client session")
+        return
+      end
+
+    client.receive("NOT AN SSL HANDSHAKE\r\n")
+
+    h.assert_true(
+      client.state() is SSLError,
+      "bytes that are not a TLS record should report SSLError")
+
+    client.dispose()
+
+class \nodoc\ iso _TestSSLReceiveUntrustedChain is UnitTest
+  """
+  A verifying session whose peer presents a chain it does not trust reports
+  `SSLAuthFail`.
+
+  The client here trusts no authority at all, so the server's certificate has
+  nothing to chain to.
+  """
+  fun name(): String => "net/ssl/SSL.receive/untrusted_chain"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.attempt(
+          h,
+          _TestSSLContext(h where client_verify = true)?,
+          _TestSSLContext(h where cert = true)?)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      client.state() is SSLAuthFail,
+      "a chain the client does not trust should report SSLAuthFail")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReceivePeerRejectedOurCert is UnitTest
+  """
+  A session whose peer rejects the certificate it presented reports
+  `SSLError`.
+
+  The client trusts no authority, so it rejects the server's certificate and
+  sends an alert. What reaches the server is that alert, not a failure of the
+  server's own verification, so the server has not failed to authenticate
+  anyone.
+  """
+  fun name(): String => "net/ssl/SSL.receive/peer_rejected_our_cert"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.attempt(
+          h,
+          _TestSSLContext(h where client_verify = true)?,
+          _TestSSLContext(
+            h where cert = true, authority = true, server_verify = true)?)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      server.state() is SSLError,
+      "a peer that rejected our certificate should report SSLError")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReceiveHostnameMismatch is UnitTest
+  """
+  A verifying session whose peer presents a certificate that is not valid for
+  the hostname reports `SSLAuthFail`.
+
+  The handshake itself succeeds here, because the certificate chains to an
+  authority the client trusts. `SSL._verify_hostname` is what rejects it.
+  """
+  fun name(): String => "net/ssl/SSL.receive/hostname_mismatch"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        let client_ctx =
+          _TestSSLContext(h where authority = true, client_verify = true)?
+        let server_ctx = _TestSSLContext(h where cert = true)?
+        _TestSSLSessionPair.attempt(
+          h, client_ctx, server_ctx where hostname = "nomatch.example.com")?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      client.state() is SSLAuthFail,
+      "a certificate that is not valid for the hostname should report "
+        + "SSLAuthFail")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReceiveNoSharedVersion is UnitTest
+  """
+  Two verifying sessions with no protocol version in common both report
+  `SSLError`.
+
+  Neither side got as far as a certificate, so neither failed to authenticate
+  the other.
+  """
+  fun name(): String => "net/ssl/SSL.receive/no_shared_version"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.attempt(
+          h,
+          _TestSSLContext(
+            h
+            where authority = true,
+              client_verify = true,
+              max_proto = TLS1u2Version())?,
+          _TestSSLContext(
+            h
+            where cert = true,
+              authority = true,
+              server_verify = true,
+              min_proto = TLS1u3Version())?)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      client.state() is SSLError,
+      "a client with no protocol version in common should report SSLError")
+    h.assert_true(
+      server.state() is SSLError,
+      "a server with no protocol version in common should report SSLError")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReceiveNoPeerCertificate is UnitTest
+  """
+  A verifying session whose peer presents no certificate at all reports
+  `SSLAuthFail`.
+
+  This is a server that asked its client to authenticate and got nothing back.
+  No chain was checked, so the verify result is `X509_V_OK` and the error queue
+  is the only place the failure is reported.
+
+  Both sides are pinned to TLS 1.3, which is what leaves the client `SSLReady`:
+  it finishes its side of the handshake before the server's alert reaches it.
+  Under TLS 1.2 the same exchange leaves the client in `SSLError`.
+  """
+  fun name(): String => "net/ssl/SSL.receive/no_peer_certificate"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.attempt(
+          h,
+          _TestSSLContext(
+            h
+            where authority = true,
+              client_verify = true,
+              min_proto = TLS1u3Version())?,
+          _TestSSLContext(
+            h
+            where cert = true,
+              authority = true,
+              server_verify = true,
+              min_proto = TLS1u3Version())?)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      server.state() is SSLAuthFail,
+      "a peer that presented no certificate should report SSLAuthFail")
+    h.assert_true(
+      client.state() is SSLReady,
+      "the client accepted the server and finished before the alert")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReceiveVerifyOffNeverAuthFails is UnitTest
+  """
+  A session created with verification off reports `SSLError` when its handshake
+  fails, whatever its peer's certificate did.
+
+  OpenSSL verifies the peer's chain even when the session is set not to enforce
+  the result, so this client carries a failed verify result for a chain it was
+  never asked to check. The server then rejects the empty certificate the
+  client sends, and that alert is what fails the handshake. Reporting
+  `SSLAuthFail` here would attribute the failure to a check the caller turned
+  off.
+
+  Each of the client's settings matters, and changing any one of them stops
+  the test exercising the guard. Load an authority and the verify result is
+  `X509_V_OK`. Give the client a certificate and it satisfies the server, so
+  both sides reach `SSLReady`. Lift the TLS 1.2 cap and the client reaches
+  `SSLReady` before the server's alert arrives.
+  """
+  fun name(): String => "net/ssl/SSL.receive/verify_off_never_auth_fails"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.attempt(
+          h,
+          _TestSSLContext(
+            h where client_verify = false, max_proto = TLS1u2Version())?,
+          _TestSSLContext(
+            h where cert = true, authority = true, server_verify = true)?)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      client.state() is SSLError,
+      "a session that was not asked to verify should report SSLError")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReceiveUnprovenCertificate is UnitTest
+  """
+  A verifying session whose peer presents a certificate it cannot prove it
+  holds reports `SSLError`, not `SSLAuthFail`.
+
+  A certificate is public, so presenting a copy of one is what an impersonator
+  without the matching key does. The chain still verifies, and OpenSSL reports
+  the failure without a certificate result, so `SSLAuthFail`'s three cases do
+  not cover it.
+
+  Flipping a byte of the server's flight is what breaks the signature. It has
+  to land inside the key exchange, past the certificate and short of the last
+  message, and it needs TLS 1.2, where those messages are not encrypted.
+  """
+  fun name(): String => "net/ssl/SSL.receive/unproven_certificate"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair._fresh_from(
+          h,
+          _TestSSLContext(
+            h
+            where authority = true,
+              client_verify = true,
+              max_proto = TLS1u2Version())?,
+          _TestSSLContext(
+            h
+            where cert = true,
+              min_proto = TLS1u2Version(),
+              max_proto = TLS1u2Version())?)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    try
+      _TestSSLTransfer(client, server)?
+
+      let flight = server.send()?
+      let at = flight.size() - 80
+      flight(at)? = flight(at)? xor 0xFF
+      client.receive(consume flight)
+    else
+      h.fail("could not corrupt the server's flight")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      client.state() is SSLError,
+      "a certificate the peer cannot prove it holds should report SSLError")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestERRCodeFields is UnitTest
+  """
+  `_ERRLibrary.of` and `_ERRReason.of` take the library and the reason out of
+  an error code the way each backend's `ERR_GET_LIB` and `ERR_GET_REASON` do.
+
+  The words below are ones the backend produced for
+  `SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE`. A handshake exercises these two
+  methods only against the backend it runs on, so a shift that is wrong for a
+  different backend still passes one.
+  """
+  fun name(): String => "net/ssl/_ERRCode/fields"
+
+  fun apply(h: TestHelper) =>
+    let code: ULong =
+      ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+        0x0A0000C7
+      elseif "openssl_1.1.x" or "libressl" then
+        0x14FFF0C7
+      else
+        compile_error "You must select an SSL version to use."
+      end
+
+    h.assert_eq[ULong](
+      _ERRLibrary.ssl(),
+      _ERRLibrary.of(code),
+      "the library the recorded word carries")
+    h.assert_eq[ULong](
+      _ERRReason.peer_did_not_return_a_certificate(),
+      _ERRReason.of(code),
+      "the reason the recorded word carries")
+
+    // 199 is `ASN1_R_UNKNOWN_SIGNATURE_ALGORITHM` in libcrypto's ASN.1, which
+    // is library 13. The reason alone does not say a peer sent no certificate.
+    let asn1: ULong =
+      ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+        (13 << 23) or 199
+      elseif "openssl_1.1.x" or "libressl" then
+        (13 << 24) or 199
+      else
+        compile_error "You must select an SSL version to use."
+      end
+
+    h.assert_eq[ULong](
+      13, _ERRLibrary.of(asn1), "the library an ASN.1 word carries")
+    h.assert_eq[ULong](
+      _ERRReason.peer_did_not_return_a_certificate(),
+      _ERRReason.of(asn1),
+      "an ASN.1 word can carry the same reason number")
+
+class \nodoc\ iso _TestSSLReceiveUntrustedClientChain is UnitTest
+  """
+  A verifying server whose client presents a chain it does not trust reports
+  `SSLAuthFail`.
+
+  The same failure as `net/ssl/SSL.receive/untrusted_chain`, from the other
+  side of the connection.
+  """
+  fun name(): String => "net/ssl/SSL.receive/untrusted_client_chain"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.attempt(
+          h,
+          _TestSSLContext(h where cert = true, client_verify = false)?,
+          _TestSSLContext(h where cert = true, server_verify = true)?)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      server.state() is SSLAuthFail,
+      "a client chain the server does not trust should report SSLAuthFail")
+
+    client.dispose()
+    server.dispose()
+
 class \nodoc\ iso _TestSSLFailedHandshakeDoesNotAffectLaterRead is UnitTest
   """
   A handshake that fails on one session does not put a session that reads
@@ -1294,9 +1854,14 @@ class \nodoc\ iso _TestSSLFailedHandshakeDoesNotAffectLaterRead is UnitTest
 
     // A handshake clears the error queue, so the failure has to be staged after
     // the healthy pair handshakes, not before.
+    // A verifying session takes entries off the queue to classify its own
+    // failure, so the session staging this one must not be verifying.
     (let failed, let failed_peer) =
       try
-        _TestSSLSessionPair.fresh(h)?
+        _TestSSLSessionPair._fresh_from(
+          h,
+          _TestSSLContext(h where client_verify = false)?,
+          _TestSSLContext(h where cert = true)?)?
       else
         h.fail("could not create an SSL session pair")
         client.dispose()
@@ -2603,7 +3168,7 @@ class \nodoc\ iso _TestSSLCanSendOnValReceiver is UnitTest
 
   fun apply(h: TestHelper) =>
     try
-      (let client: SSL val, _) = _TestSSLContext(h)?
+      (let client: SSL val, _) = _TestSSLDefaultSessions(h)?
 
       h.assert_true(
         client.can_send(),

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -29,7 +29,9 @@ use @SSL_write[I32](ssl: Pointer[_SSL], buf: Pointer[U8] tag, len: I32)
 use @BIO_read[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: I32)
 use @BIO_write[I32](bio: Pointer[_BIO] tag, buf: Pointer[U8] tag, len: I32)
 use @SSL_get_error[I32](ssl: Pointer[_SSL], ret: I32)
+use @SSL_get_verify_result[ILong](ssl: Pointer[_SSL] tag)
 use @ERR_clear_error[None]()
+use @ERR_get_error[ULong]()
 use @BIO_ctrl_pending[USize](bio: Pointer[_BIO] tag)
 use @SSL_has_pending[I32](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x"
 use @SSL_get_peer_certificate[Pointer[X509]](ssl: Pointer[_SSL]) if "openssl_1.1.x" or "libressl"
@@ -48,6 +50,57 @@ primitive _SSLErrorCode
   fun syscall(): I32 => 5
   fun zero_return(): I32 => 6
 
+primitive _X509VerifyResult
+  """
+  `SSL_get_verify_result` results, from `openssl/x509_vfy.h`.
+  """
+  fun ok(): ILong => 0
+
+primitive _ERRLibrary
+  """
+  Which OpenSSL library raised an error, and the one value this package
+  compares that against. `of` takes the field from where each backend's
+  `ERR_GET_LIB` does, because OpenSSL 3.0 moved it.
+
+  Any OpenSSL library can put an entry on the thread's error queue, so `ssl()`
+  is one of several libraries `of` can name. OpenSSL 3.0 also packs system
+  errors into the same word, under a flag that neither `_ERRLibrary.of` nor
+  `_ERRReason.of` reads. A system-flagged word decodes to a library that is not
+  `ssl()`, so it cannot match.
+  """
+  fun of(code: ULong): ULong =>
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+      (code >> 23) and 0xFF
+    elseif "openssl_1.1.x" or "libressl" then
+      (code >> 24) and 0xFF
+    else
+      compile_error "You must select an SSL version to use."
+    end
+
+  fun ssl(): ULong => 20
+
+primitive _ERRReason
+  """
+  Why an OpenSSL library raised an error, and the one value this package
+  compares that against. `of` masks the field the way each backend's
+  `ERR_GET_REASON` does, because OpenSSL 3.0 widened it.
+
+  A reason number means one thing in the library that raised it and something
+  else in another, so compare it only after `_ERRLibrary.of` has named that
+  library. 199 is `SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE` in libssl and
+  `ASN1_R_UNKNOWN_SIGNATURE_ALGORITHM` in libcrypto's ASN.1.
+  """
+  fun of(code: ULong): ULong =>
+    ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+      code and 0x7FFFFF
+    elseif "openssl_1.1.x" or "libressl" then
+      code and 0xFFF
+    else
+      compile_error "You must select an SSL version to use."
+    end
+
+  fun peer_did_not_return_a_certificate(): ULong => 199
+
 primitive SSLHandshake
   """
   The session is still handshaking.
@@ -55,7 +108,16 @@ primitive SSLHandshake
 
 primitive SSLAuthFail
   """
-  The peer's certificate could not be verified.
+  The session required a certificate from its peer and did not get an
+  acceptable one. The chain did not verify, or the certificate was not valid
+  for the hostname the session was created with, or the peer presented none at
+  all.
+
+  Two failures a caller might expect here report `SSLError` instead: a peer
+  that presents a certificate it cannot prove it holds, and one whose
+  certificate will not parse. A session created with verification off does not
+  reach this state at all, and neither does a session whose only failure was
+  its peer rejecting the certificate the session presented.
   """
 
 primitive SSLReady
@@ -65,7 +127,12 @@ primitive SSLReady
 
 primitive SSLError
   """
-  The session failed.
+  The session failed for a reason other than the one `SSLAuthFail` names. A
+  session reports this when its peer did not speak TLS, shared no protocol
+  version, rejected the certificate the session presented, presented a
+  certificate it could not prove it holds, or presented one that would not
+  parse. A session created with verification off reports it for every failure,
+  and so does any session that fails after its handshake.
   """
 
 primitive SSLDisposed
@@ -293,7 +360,8 @@ class SSL
         _verify_hostname()
       else
         match @SSL_get_error(_ssl, r)
-        | _SSLErrorCode.ssl() => _state = SSLAuthFail
+        | _SSLErrorCode.ssl() =>
+          _state = if _peer_auth_failed() then SSLAuthFail else SSLError end
         | _SSLErrorCode.syscall() | _SSLErrorCode.zero_return() =>
           _state = SSLError
         end
@@ -351,6 +419,47 @@ class SSL
     if not _ssl.is_null() then
       @SSL_free(_ssl)
     end
+
+  fun _peer_auth_failed(): Bool =>
+    """
+    Whether the `SSL_ERROR_SSL` the caller just got from `SSL_do_handshake` was
+    this session rejecting its peer's certificate.
+
+    True for a chain that did not verify and for a peer that sent no
+    certificate when one was required. False for a peer that sent a certificate
+    it could not prove it holds, and for one whose certificate would not parse:
+    OpenSSL reports those as SSL-layer errors that name no certificate result,
+    and there is no reason code for them that means the same thing on every
+    backend.
+
+    Callers must have checked that `_ssl` is not null, and must arrive with the
+    thread's error queue as `SSL_do_handshake` left it. A peer that sent no
+    certificate leaves its reason only on that queue, so an OpenSSL call that
+    clears the queue in between loses it and this returns false.
+    """
+    if not _verify then return false end
+
+    if @SSL_get_verify_result(_ssl) != _X509VerifyResult.ok() then
+      return true
+    end
+
+    // A failure inside libcrypto puts its own entry on the queue before libssl
+    // puts this one there, so the entry to look at is not always the first.
+    // Taking entries off is safe because every `SSL_*` call clears the queue
+    // before it runs.
+    var code = @ERR_get_error()
+    while code != 0 do
+      if
+        (_ERRLibrary.of(code) == _ERRLibrary.ssl())
+          and (_ERRReason.of(code)
+            == _ERRReason.peer_did_not_return_a_certificate())
+      then
+        return true
+      end
+      code = @ERR_get_error()
+    end
+
+    false
 
   fun ref _verify_hostname() =>
     """

--- a/ssl/net/ssl_connection.pony
+++ b/ssl/net/ssl_connection.pony
@@ -4,6 +4,13 @@ use "net"
 class SSLConnection is TCPConnectionNotify
   """
   Wrap another protocol in an SSL connection.
+
+  A finished handshake reaches the wrapped protocol as `connected` on a session
+  that connected out, or `accepted` on one that was connected to. A failed one
+  reaches it as `auth_failed` when the session is in `SSLAuthFail`, and as
+  nothing at all when the session is in `SSLError`. The connection closes on
+  either failure. `SSLAuthFail` and `SSLError` each list the failures they
+  cover.
   """
   let _notify: TCPConnectionNotify
   let _ssl: SSL

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -155,9 +155,9 @@ class val SSLContext
 
   fun val client(hostname: String = ""): SSL iso^ ? =>
     """
-    Create a client-side SSL session. If a hostname is supplied, the server
-    side certificate must be valid for that hostname. Raises an error if the
-    context has been disposed.
+    Create a client-side SSL session. If a hostname is supplied and client
+    verification is on, the server side certificate must be valid for that
+    hostname. Raises an error if the context has been disposed.
 
     The session holds the context, so the context lives for as long as the
     session can handshake.
@@ -299,12 +299,21 @@ class val SSLContext
   fun ref set_client_verify(state: Bool) =>
     """
     Set to true to require verification. Defaults to true.
+
+    A client session created with `state` false never reports `SSLAuthFail`,
+    and an `SSLConnection` wrapping one never calls the wrapped protocol's
+    `auth_failed`.
     """
     _client_verify = state
 
   fun ref set_server_verify(state: Bool) =>
     """
     Set to true to require verification. Defaults to false.
+
+    A server session created with `state` false never reports `SSLAuthFail`,
+    and an `SSLConnection` wrapping one never calls the wrapped protocol's
+    `auth_failed`. It sends no certificate request, so it has no peer identity
+    to reject.
     """
     _server_verify = state
 


### PR DESCRIPTION
`SSLAuthFail`'s docstring was one line: "The peer's certificate could not be verified." A session set that state for every SSL-layer handshake failure, bytes that were not a TLS record and two sessions with no protocol version in common included, with the certificate check reporting no problem. Since `SSLConnection` calls the wrapped protocol's `auth_failed` for a session in that state, bytes from a peer that spoke no TLS came back to an application as an authentication failure.

A failed handshake now reports `SSLAuthFail` only when the session was created with verification on and either the peer's chain did not verify or the peer presented no certificate when one was required. The other place `SSLAuthFail` gets set, for a certificate that is not valid for the hostname, runs on a handshake that succeeded and is untouched. `SSL.read` already reported `SSLError` for the same class of failure and is untouched too.

Two authentication failures report `SSLError` on purpose, and that is the part worth arguing about. A peer presenting a certificate it cannot prove it holds, and a peer whose certificate will not parse, both reported `SSLAuthFail` on `main` and report `SSLError` here: the chain verifies, so the verify result is `X509_V_OK`, and the SSL reasons are 123 and 524301 rather than 199. Certificates are public, so presenting a copy of the real one is what an impersonator without the key does, which means the attacker picks the quieter failure. I left it narrow anyway. A reason set is not portable. On LibreSSL the client-auth direction of that same failure raises an EVP error rather than an SSL one, so the same failure would land in different states on different backends. "Did the peer present a certificate" does not work either: it would fire for an ALPN failure that happens after the certificate arrives, and OpenSSL does not retain the peer certificate after a failed handshake. Covering it properly needs its own design, most likely a verify callback. Nothing is bypassed: the connection closes either way and no plaintext is delivered. But an application that alerts on `auth_failed` loses that alert for the case that most deserves it. A test pins the boundary, so moving it has to be deliberate.

For a wrapped protocol this leaves three outcomes distinguishable where there were two. An authentication failure gives `auth_failed` then `closed`. Any other handshake failure gives `closed` with no `connected` or `accepted` before it, because `SSLConnection` swallows the TCP-level events and re-issues them only from `_poll`'s `SSLReady` arm. A peer disconnecting normally gives `closed` after one of them. Before this, `auth_failed` fired for both kinds of failure and said nothing about which. One case stays unreadable and is unchanged here: a peer that rejects the session after it has reached `SSLReady` arrives as `connected` then `closed`.

`set_server_verify` defaults to `false`, so a default `SSLConnection` server never reports `SSLAuthFail` now and never calls `auth_failed`. It could before. It sends no certificate request, so it has no peer identity to reject.

607 of the 759 inserted lines are tests. Eleven tests are new: nine drive `SSL` in memory, one runs a real `SSLConnection` against a plain TCP server answering a TLS client with HTTP, and one is a unit test on the error-code field extraction. Each part of the rule has a test that fails when it is deleted: the untrusted-chain tests on both sides for the verify result, the no-peer-certificate test for the reason scan, the verification-off test for the verify guard, and the non-TLS-bytes, no-shared-version, peer-rejected-our-certificate and `SSLConnection` tests for the classification itself. Three things below that are not covered. Four assert a state `main` already produces, and those are what stops someone narrowing the rule too far.

The verification-off test does not pin the reason the guard exists. `_peer_auth_failed` returns on `not _verify` before it reads the verify result, so it passes whether or not OpenSSL recorded one. OpenSSL does record one for a client created with `set_client_verify(false)`. Deleting the guard is what makes that test fail.

Three mutations in `_peer_auth_failed` no test fails on, and I could not construct one that does: widening the OpenSSL 3.x reason mask to the 1.1.x one, dropping the per-entry library check, and reading only the head instead of scanning the queue. None is reachable through the public API — both masks give the same value for every reason a backend raises, and nothing in the package puts a foreign entry on the queue ahead of a real one on demand. What the new unit test does pin is the extraction the guard rests on: the per-backend shifts, and that `_ERRLibrary.of` tells libraries apart rather than answering `ssl()` for everything. The handshake tests catch neither.

The suite passes on the five Linux backend configurations CI builds: OpenSSL 1.1.1w, 3.6.2 and 4.0.0, and LibreSSL 3.9.2 and 4.2.1. The two Windows jobs build against LibreSSL 3.9.1, which I did not run locally.

Closes #118
