### PR TITLE
Fix unproven peer certificates reporting SSLError instead of SSLAuthFail

### DIFF
--- a/.release-notes/fix-unproven-cert-auth-fail.md
+++ b/.release-notes/fix-unproven-cert-auth-fail.md
@@ -1,0 +1,3 @@
+## Fix unproven peer certificates reporting SSLError instead of SSLAuthFail
+
+A peer that presents a certificate it cannot prove it holds — an impersonator with a copy of the certificate but not the matching private key — now reports `SSLAuthFail`. Previously it reported `SSLError`, so `SSLConnection` closed the connection without calling `auth_failed` on the wrapped notify.

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -1696,12 +1696,12 @@ class \nodoc\ iso _TestSSLReceiveVerifyOffNeverAuthFails is UnitTest
 class \nodoc\ iso _TestSSLReceiveUnprovenCertificate is UnitTest
   """
   A verifying session whose peer presents a certificate it cannot prove it
-  holds reports `SSLError`, not `SSLAuthFail`.
+  holds reports `SSLAuthFail`.
 
   A certificate is public, so presenting a copy of one is what an impersonator
-  without the matching key does. The chain still verifies, and OpenSSL reports
-  the failure without a certificate result, so `SSLAuthFail`'s three cases do
-  not cover it.
+  without the matching key does. The chain verifies — the certificate is
+  genuine — but the handshake signature check fails, and the peer certificate
+  is still stored in the session.
 
   Flipping a byte of the server's flight is what breaks the signature. It has
   to land inside the key exchange, past the certificate and short of the last
@@ -1744,8 +1744,8 @@ class \nodoc\ iso _TestSSLReceiveUnprovenCertificate is UnitTest
     end
 
     h.assert_true(
-      client.state() is SSLError,
-      "a certificate the peer cannot prove it holds should report SSLError")
+      client.state() is SSLAuthFail,
+      "a certificate the peer cannot prove it holds should report SSLAuthFail")
 
     client.dispose()
     server.dispose()

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -109,15 +109,17 @@ primitive SSLHandshake
 primitive SSLAuthFail
   """
   The session required a certificate from its peer and did not get an
-  acceptable one. The chain did not verify, or the certificate was not valid
-  for the hostname the session was created with, or the peer presented none at
-  all.
+  acceptable one. The chain did not verify, the certificate was not valid for
+  the hostname the session was created with, the peer could not prove it holds
+  the key matching the certificate it presented, or the peer presented no
+  certificate at all.
 
-  Two failures a caller might expect here report `SSLError` instead: a peer
-  that presents a certificate it cannot prove it holds, and one whose
-  certificate will not parse. A session created with verification off does not
-  reach this state at all, and neither does a session whose only failure was
-  its peer rejecting the certificate the session presented.
+  A peer whose certificate will not parse reports `SSLError` instead: the
+  failure happens before chain verification, so it is not distinguishable from
+  a failure that had nothing to do with a certificate. A session created with
+  verification off does not reach this state at all, and neither does a
+  session whose only failure was its peer rejecting the certificate the
+  session presented.
   """
 
 primitive SSLReady
@@ -129,10 +131,9 @@ primitive SSLError
   """
   The session failed for a reason other than the one `SSLAuthFail` names. A
   session reports this when its peer did not speak TLS, shared no protocol
-  version, rejected the certificate the session presented, presented a
-  certificate it could not prove it holds, or presented one that would not
-  parse. A session created with verification off reports it for every failure,
-  and so does any session that fails after its handshake.
+  version, rejected the certificate the session presented, or presented one
+  that would not parse. A session created with verification off reports it for
+  every failure, and so does any session that fails after its handshake.
   """
 
 primitive SSLDisposed
@@ -420,17 +421,17 @@ class SSL
       @SSL_free(_ssl)
     end
 
-  fun _peer_auth_failed(): Bool =>
+  fun ref _peer_auth_failed(): Bool =>
     """
     Whether the `SSL_ERROR_SSL` the caller just got from `SSL_do_handshake` was
     this session rejecting its peer's certificate.
 
-    True for a chain that did not verify and for a peer that sent no
-    certificate when one was required. False for a peer that sent a certificate
-    it could not prove it holds, and for one whose certificate would not parse:
-    OpenSSL reports those as SSL-layer errors that name no certificate result,
-    and there is no reason code for them that means the same thing on every
-    backend.
+    True for a chain that did not verify, for a peer that sent no certificate
+    when one was required, and for a peer that presented a certificate but
+    could not prove it holds the matching key. False for a peer whose
+    certificate would not parse: the failure happens before chain verification,
+    so it is not distinguishable from one that had nothing to do with a
+    certificate.
 
     Callers must have checked that `_ssl` is not null, and must arrive with the
     thread's error queue as `SSL_do_handshake` left it. A peer that sent no
@@ -457,6 +458,26 @@ class SSL
         return true
       end
       code = @ERR_get_error()
+    end
+
+    // A peer that presented a certificate it could not prove it holds still
+    // has that certificate stored in the session. The chain verified, or the
+    // check above would have caught it, and no "no certificate" reason was on
+    // the queue. A non-null peer certificate at this point means the handshake
+    // failed after the peer's credentials were received — an authentication
+    // failure, whatever error code the backend reported.
+    let cert =
+      ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+        @SSL_get1_peer_certificate(_ssl)
+      elseif "openssl_1.1.x" or "libressl" then
+        @SSL_get_peer_certificate(_ssl)
+      else
+        compile_error "You must select an SSL version to use."
+      end
+
+    if not cert.is_null() then
+      @X509_free(cert)
+      return true
     end
 
     false


### PR DESCRIPTION
The existing checks in `_peer_auth_failed` — chain verification result and error queue scan — miss the case where a peer presents a certificate it cannot prove it holds. The chain verifies (the certificate is genuine), no "no certificate" reason appears on the queue, and the error codes for the signature failure differ across OpenSSL and LibreSSL.

After the existing checks, a non-null peer certificate means the handshake failed after the peer's credentials were received. That is an authentication failure regardless of which error code the backend used.

A peer whose certificate will not parse remains `SSLError` — the failure happens before chain verification, so it is not distinguishable from one that had nothing to do with a certificate.

Closes #132
