### PR TITLE
Fix receive reporting inconsistent state when a callback contaminates the error queue

### DIFF
--- a/.release-notes/fix-alpn-queue-contamination.md
+++ b/.release-notes/fix-alpn-queue-contamination.md
@@ -1,0 +1,3 @@
+## Fix receive reporting inconsistent state when a callback contaminates the error queue
+
+A callback running during the TLS handshake — such as an ALPN resolver — could change whether `auth_failed` fired on the connection notify. The same handshake failure could produce `SSLAuthFail` or `SSLError` depending on what the callback happened to call internally, because one OpenSSL error code bypassed the authentication-failure classification that the other went through. Both error codes now take the same classification path, so the reported state depends on what failed, not on what the callback did.

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -30,6 +30,7 @@ actor \nodoc\ Main is TestList
     test(_TestSSLReceiveVerifyOffNeverAuthFails)
     test(_TestSSLReceiveUnprovenCertificate)
     test(_TestSSLReceiveUntrustedClientChain)
+    test(_TestSSLReceiveALPNFatalWithQueuedError)
     test(_TestERRCodeFields)
     test(_TestSSLFailedHandshakeDoesNotAffectLaterRead)
     test(_TestSSLReadReportsGenuineError)
@@ -1828,6 +1829,68 @@ class \nodoc\ iso _TestSSLReceiveUntrustedClientChain is UnitTest
     client.dispose()
     server.dispose()
 
+class \nodoc\ iso _TestSSLReceiveALPNFatalWithQueuedError is UnitTest
+  """
+  An ALPN resolver that rejects the protocol reports the same state whether
+  or not it leaves a system error on the thread's error queue.
+
+  A clean `ALPNFatal` puts `ssl routines::no application protocol` on the
+  queue, so `SSL_get_error` returns `SSL_ERROR_SSL`. A resolver that
+  fails an OpenSSL call first puts a system error as the older entry, and
+  `SSL_get_error` returns `SSL_ERROR_SYSCALL` instead. Both error codes must
+  reach the same classification logic, or the reported state depends on what
+  the resolver happened to call.
+  """
+  fun name(): String => "net/ssl/SSL.receive/alpn_fatal_with_queued_error"
+
+  fun apply(h: TestHelper) =>
+    let auth = FileAuth(h.env.root)
+
+    let clean_state = _attempt(h, _TestALPNFatalResolver)
+    let dirty_state =
+      _attempt(h, _TestALPNContaminatingFatalResolver(auth))
+
+    h.assert_true(
+      clean_state is dirty_state,
+      "queue contamination from the resolver changed the server's state")
+
+  fun _attempt(
+    h: TestHelper,
+    resolver: ALPNProtocolResolver val)
+    : SSLState
+  =>
+    let auth = FileAuth(h.env.root)
+    let sslctx =
+      try
+        recover val
+          SSLContext
+            .> set_authority(FilePath(auth, "assets/cert.pem"))?
+            .> set_cert(
+                FilePath(auth, "assets/cert.pem"),
+                FilePath(auth, "assets/key.pem"))?
+            .> set_client_verify(false)
+            .> set_server_verify(false)
+            .> alpn_set_client_protocols(["h2"])
+            .> alpn_set_resolver(resolver)
+        end
+      else
+        h.fail("ssl context setup failed")
+        return SSLHandshake
+      end
+
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.attempt(h, sslctx, sslctx)?
+      else
+        h.fail("could not create an SSL session pair")
+        return SSLHandshake
+      end
+
+    let state = server.state()
+    client.dispose()
+    server.dispose()
+    state
+
 class \nodoc\ iso _TestSSLFailedHandshakeDoesNotAffectLaterRead is UnitTest
   """
   A handshake that fails on one session does not put a session that reads
@@ -2582,6 +2645,34 @@ class \nodoc\ iso _TestSSLContextALPNSetResolverAfterDispose is UnitTest
     h.assert_false(
       ctx.alpn_set_resolver(resolver),
       "alpn_set_resolver() on a disposed context should return false")
+
+class \nodoc\ val _TestALPNFatalResolver is ALPNProtocolResolver
+  fun box resolve(advertised: Array[ALPNProtocolName] val): ALPNMatchResult =>
+    ALPNFatal
+
+class \nodoc\ val _TestALPNContaminatingFatalResolver
+  is ALPNProtocolResolver
+  """
+  Rejects every advertisement and leaves a system error on the thread's error
+  queue. The failed `set_cert` call inside `resolve` pushes the error;
+  OpenSSL then pushes its own `ssl routines::no application protocol` entry
+  on top. Because the system error is the older one, `SSL_get_error` returns
+  `SSL_ERROR_SYSCALL` instead of `SSL_ERROR_SSL`.
+  """
+  let _auth: FileAuth
+
+  new val create(auth: FileAuth) =>
+    _auth = auth
+
+  fun box resolve(advertised: Array[ALPNProtocolName] val): ALPNMatchResult =>
+    let ctx = SSLContext
+    try
+      ctx.set_cert(
+        FilePath(_auth, "/nonexistent/cert.pem"),
+        FilePath(_auth, "/nonexistent/key.pem"))?
+    end
+    ctx.dispose()
+    ALPNFatal
 
 class \nodoc\ val _TestALPNFixedResolver is ALPNProtocolResolver
   """

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -361,9 +361,9 @@ class SSL
         _verify_hostname()
       else
         match @SSL_get_error(_ssl, r)
-        | _SSLErrorCode.ssl() =>
+        | _SSLErrorCode.ssl() | _SSLErrorCode.syscall() =>
           _state = if _peer_auth_failed() then SSLAuthFail else SSLError end
-        | _SSLErrorCode.syscall() | _SSLErrorCode.zero_return() =>
+        | _SSLErrorCode.zero_return() =>
           _state = SSLError
         end
       end
@@ -423,8 +423,8 @@ class SSL
 
   fun ref _peer_auth_failed(): Bool =>
     """
-    Whether the `SSL_ERROR_SSL` the caller just got from `SSL_do_handshake` was
-    this session rejecting its peer's certificate.
+    Whether the handshake failure the caller just got from `SSL_do_handshake`
+    was this session rejecting its peer's certificate.
 
     True for a chain that did not verify, for a peer that sent no certificate
     when one was required, and for a peer that presented a certificate but
@@ -432,6 +432,12 @@ class SSL
     certificate would not parse: the failure happens before chain verification,
     so it is not distinguishable from one that had nothing to do with a
     certificate.
+
+    Called for both `SSL_ERROR_SSL` and `SSL_ERROR_SYSCALL`. A callback that
+    runs inside `SSL_do_handshake` can push an entry onto the thread's error
+    queue, changing `SSL_get_error` from one to the other without changing what
+    actually failed. Routing both through this method keeps the reported state
+    consistent.
 
     Callers must have checked that `_ssl` is not null, and must arrive with the
     thread's error queue as `SSL_do_handshake` left it. A peer that sent no


### PR DESCRIPTION
`SSL_get_error` reports what is on the thread's error queue, not what the call did. A callback running inside `SSL_do_handshake` — like the ALPN select callback — can push an entry that changes `SSL_get_error` from `SSL_ERROR_SSL` to `SSL_ERROR_SYSCALL` without changing what actually failed.

`receive` routed only `SSL_ERROR_SSL` through `_peer_auth_failed()`; `SSL_ERROR_SYSCALL` mapped directly to `SSLError`. An ALPN resolver that happened to fail an OpenSSL call before returning `ALPNFatal` would leave a system error on the queue, shift `SSL_get_error` to `SSL_ERROR_SYSCALL`, and bypass the classification logic entirely. Both error codes now go through `_peer_auth_failed()`, so the reported state depends on what failed, not on what the callback happened to call.

Closes #119
