### PR TITLE
Add else branches to SSL_get_error matches in read and receive

### DIFF
--- a/ssl/net/_unreachable.pony
+++ b/ssl/net/_unreachable.pony
@@ -1,0 +1,26 @@
+use @pony_os_stderr[Pointer[U8]]()
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @exit[None](status: I32)
+
+primitive _Unreachable
+  """
+  Panic for a code path that should be structurally impossible.
+
+  Print the file, line, and method to stderr, then exit. Use it in an `else`
+  branch the surrounding code has already ruled out, so that if the impossible
+  ever does happen the program stops with a location instead of silently
+  continuing.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      "Unreachable code reached at %s:%lu in %s.%s\n".cstring(),
+      loc.file().cstring(),
+      loc.line(),
+      loc.type_name().cstring(),
+      loc.method_name().cstring())
+    @fprintf(
+      @pony_os_stderr(),
+      "Please open an issue at https://github.com/ponylang/ssl/issues\n"
+        .cstring())
+    @exit(1)

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -297,6 +297,9 @@ class SSL
         return None
       | _SSLErrorCode.want_read() =>
         return None
+      else
+        _Unreachable()
+        return None
       end
     end
 
@@ -365,6 +368,10 @@ class SSL
           _state = if _peer_auth_failed() then SSLAuthFail else SSLError end
         | _SSLErrorCode.zero_return() =>
           _state = SSLError
+        | _SSLErrorCode.want_read() =>
+          None
+        else
+          _Unreachable()
         end
       end
     end


### PR DESCRIPTION
Nothing reaches the fall-through today — the issue traces every `SSL_get_error` result against the constraints of memory BIOs and the package's callback surface. But a missing `else` means a future change to OpenSSL or to this package's API surface would produce silent misbehavior rather than a crash with a location.

In `receive`, `SSL_ERROR_WANT_READ` was handled by the implicit fall-through (doing nothing — correct for a handshake needing more data). Making it explicit lets the `else` be `_Unreachable` rather than a silent no-op.

Closes #120
