### PR TITLE
Fix SSL.write silently losing data when encryption fails

### DIFF
--- a/.release-notes/fix-write-return-value.md
+++ b/.release-notes/fix-write-return-value.md
@@ -1,0 +1,3 @@
+## Fix SSL.write silently losing data when encryption fails
+
+`SSL.write` could report success when it encrypted nothing. A TLS 1.2 peer that started a renegotiation triggered this: the session was still `SSLReady`, but the write produced no ciphertext and the payload was gone. `write` now raises an error when it cannot encrypt the data. A fatal encryption failure also sets the session to `SSLError`.

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -2707,8 +2707,8 @@ class \nodoc\ iso _TestSSLSendAfterDispose is UnitTest
 class \nodoc\ iso _TestSSLWriteAfterDispose is UnitTest
   """
   `write` on a disposed session does nothing and does not raise. Being disposed
-  is not an error, and `write`'s only error means the handshake is not
-  complete, which is not what happened here.
+  is not an error: `write` raises when the handshake is not complete or when
+  `SSL_write` cannot encrypt, neither of which is what happened here.
 
   The session reaches `SSLReady` first, so the dispose is the only reason
   `write` could have to stop, and `state` reports `SSLDisposed` afterwards.

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -340,7 +340,7 @@ class SSL
     """
     When application data is sent, add it to the SSL session. Does nothing if
     the session has been disposed. Raises an error if the handshake is not
-    complete.
+    complete or if `SSL_write` does not encrypt the data.
     """
     if _ssl.is_null() then return end
     if _state isnt SSLReady then error end
@@ -352,7 +352,20 @@ class SSL
       while offset < total do
         let chunk = (total - offset).min(max_chunk)
         @ERR_clear_error()
-        @SSL_write(_ssl, data.cpointer(offset), chunk.i32())
+        let r = @SSL_write(_ssl, data.cpointer(offset), chunk.i32())
+        if r <= 0 then
+          match @SSL_get_error(_ssl, r)
+          | _SSLErrorCode.ssl()
+          | _SSLErrorCode.syscall()
+          | _SSLErrorCode.zero_return() =>
+            _state = SSLError
+          | _SSLErrorCode.want_read() =>
+            None
+          else
+            _Unreachable()
+          end
+          error
+        end
         offset = offset + chunk
       end
     end


### PR DESCRIPTION
`SSL.write` discarded `SSL_write`'s return value, so it reported success even when the call encrypted nothing. A TLS 1.2 peer that started a renegotiation hit this: the session was still `SSLReady`, `SSL_write` returned `SSL_ERROR_WANT_READ`, and the payload was gone with no signal to the caller.

`write` now checks `SSL_write`'s return value and raises on failure. Fatal errors (`SSL_ERROR_SSL`, `SSL_ERROR_SYSCALL`, `SSL_ERROR_ZERO_RETURN`) set `_state = SSLError`; a transient `SSL_ERROR_WANT_READ` raises without changing state. The error dispatch mirrors `read()`.

All three callers in `SSLConnection` already wrap `write` in `try`/`else`, so no caller changes are needed.

Closes #122
