### PR TITLE
Fix client sessions not reporting immediate handshake failures

### DIFF
--- a/.release-notes/fix-create-handshake-classification.md
+++ b/.release-notes/fix-create-handshake-classification.md
@@ -1,0 +1,3 @@
+## Fix client sessions not reporting immediate handshake failures
+
+A client session created from a context with no usable protocol version or cipher suite stayed in `SSLHandshake` after construction instead of reporting `SSLError`. The session appeared to be negotiating when it could never succeed.

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -21,6 +21,7 @@ actor \nodoc\ Main is TestList
       _TestALPNProtocolListOffsetOfRoundtrip))
     test(_TestALPNStandardProtocolResolver)
     test(_TestSSLHandshakeInMemory)
+    test(_TestSSLCreateClientNoAvailableProtocol)
     test(_TestSSLReceiveNonTLSBytes)
     test(_TestSSLReceiveUntrustedChain)
     test(_TestSSLReceivePeerRejectedOurCert)
@@ -1447,6 +1448,44 @@ class \nodoc\ iso _TestSSLHandshakeInMemory is UnitTest
 
     client.dispose()
     server.dispose()
+
+class \nodoc\ iso _TestSSLCreateClientNoAvailableProtocol is UnitTest
+  """
+  A client session whose context has no available protocol version reports
+  `SSLError` immediately after construction.
+
+  The context allows only TLS 1.2 and then disables it via options, leaving no
+  version for the handshake to use. `SSL_do_handshake` fails during `_create`,
+  and the session classifies that failure before the constructor returns.
+  """
+  fun name(): String => "net/ssl/SSL._create/no_available_protocol"
+
+  fun apply(h: TestHelper) =>
+    let ctx =
+      try
+        recover val
+          SSLContext
+            .> set_max_proto_version(TLS1u2Version())?
+            .> allow_tls_v1_2(false)
+        end
+      else
+        h.fail("ssl context setup failed")
+        return
+      end
+
+    let client =
+      try
+        ctx.client()?
+      else
+        h.fail("client() raised on a misconfigured context")
+        return
+      end
+
+    h.assert_true(
+      client.state() is SSLError,
+      "a client with no available protocol should report SSLError")
+
+    client.dispose()
 
 class \nodoc\ iso _TestSSLReceiveNonTLSBytes is UnitTest
   """

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -221,8 +221,7 @@ class SSL
       @SSL_set_accept_state(_ssl)
     else
       @SSL_set_connect_state(_ssl)
-      @ERR_clear_error()
-      @SSL_do_handshake(_ssl)
+      _do_handshake()
     end
 
   fun box alpn_selected(): (ALPNProtocolName | None) =>
@@ -390,23 +389,7 @@ class SSL
     end
 
     if _state is SSLHandshake then
-      @ERR_clear_error()
-      let r = @SSL_do_handshake(_ssl)
-
-      if r > 0 then
-        _verify_hostname()
-      else
-        match @SSL_get_error(_ssl, r)
-        | _SSLErrorCode.ssl() | _SSLErrorCode.syscall() =>
-          _state = if _peer_auth_failed() then SSLAuthFail else SSLError end
-        | _SSLErrorCode.zero_return() =>
-          _state = SSLError
-        | _SSLErrorCode.want_read() =>
-          None
-        else
-          _Unreachable()
-        end
-      end
+      _do_handshake()
     end
 
   fun can_send(): Bool =>
@@ -528,6 +511,30 @@ class SSL
     end
 
     false
+
+  fun ref _do_handshake() =>
+    """
+    Run one step of the TLS handshake and classify the outcome. Sets `_state`
+    to `SSLReady`, `SSLAuthFail`, or `SSLError` when the handshake settles,
+    and leaves it at `SSLHandshake` when more data is needed.
+    """
+    @ERR_clear_error()
+    let r = @SSL_do_handshake(_ssl)
+
+    if r > 0 then
+      _verify_hostname()
+    else
+      match @SSL_get_error(_ssl, r)
+      | _SSLErrorCode.ssl() | _SSLErrorCode.syscall() =>
+        _state = if _peer_auth_failed() then SSLAuthFail else SSLError end
+      | _SSLErrorCode.zero_return() =>
+        _state = SSLError
+      | _SSLErrorCode.want_read() =>
+        None
+      else
+        _Unreachable()
+      end
+    end
 
   fun ref _verify_hostname() =>
     """


### PR DESCRIPTION
`SSL._create` called `SSL_do_handshake` for a client and discarded the return value. When the handshake failed immediately — no available protocol version, no usable cipher suite — the session stayed in `SSLHandshake` instead of `SSLError`.

Extract `_do_handshake` so both `_create` and `receive` classify the result through the same code path.

Closes #128
