### PR TITLE
Add SSL.shutdown to send close_notify; split SSLPeerClosed off SSLError

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,6 +1,6 @@
 ## Add SSL.shutdown
 
-Calling `SSL.shutdown` queues a TLS `close_notify` alert into the session's output BIO. The alert bytes come out through `send`, the same way handshake and application data do.
+`SSL.shutdown` sends a TLS `close_notify` to the peer. Call it before closing the transport, so a peer reading TCP EOF sees an orderly end of stream instead of a truncation. Without it, an OpenSSL peer treats the missing alert as an attack and reports the stream as truncated.
 
 ```pony
 session.shutdown()
@@ -9,25 +9,15 @@ while session.can_send() do
 end
 ```
 
-Without an alert on the wire before the transport closes, an OpenSSL peer that reads TCP EOF without an alert reports `SSL_R_UNEXPECTED_EOF_WHILE_READING`, its signal for a truncated stream. RFC 8446 §6.1 requires each party to send `close_notify` before closing its write side.
+`shutdown` runs from `SSLReady` (initiating) and from `SSLPeerClosed` (reciprocating the peer's alert). Repeating the call is a no-op. After it returns, `write` on the session raises: this package does not offer TLS half-close.
 
-`shutdown` runs from `SSLReady` (initiating) and from `SSLPeerClosed` (reciprocating the peer's alert). If `SSL_shutdown` fails, the session moves to `SSLError` — the caller draining the output BIO sees no bytes and can react instead of closing the transport with silent truncation.
-
-After `shutdown` returns, `write` on the session raises. This package does not offer TLS half-close: application writes after our own or the peer's `close_notify` are refused.
-
-`SSLConnection` does not send `close_notify` on close in either direction — its `closed` hook fires after the transport is gone. A protocol that needs the alert on the wire has to use `SSL` directly.
+`SSLConnection` does not send `close_notify` on close, in either direction — its `closed` hook fires after the transport is gone. A protocol that needs the alert on the wire has to use `SSL` directly.
 
 ## Split SSLPeerClosed from SSLError
 
-A session whose peer sent `close_notify` now has state `SSLPeerClosed`. That case used to fold into `SSLError` alongside decryption failures and dropped connections, so a clean end of stream and a failure were indistinguishable.
+A session whose peer sent `close_notify` now reports `SSLPeerClosed`, not `SSLError`. Before, a clean end of stream and a failure looked the same to a caller matching on state.
 
-`SSL.read` on a session in `SSLPeerClosed` still surfaces any bytes decrypted before the peer's `close_notify` — the same way `SSLError` does. The next read past those bytes returns `None`.
-
-`SSL.receive` on a session in `SSLPeerClosed` drops the bytes. `SSL.write` raises, as on any non-`SSLReady` state.
-
-`SSLPeerClosed` is added to the public `SSLState` union. A caller that matched on `SSLError` after `SSL.read` to detect any end of a session needs an added arm; a `match \exhaustive\` on `SSLState` needs an arm for the new variant.
-
-Before:
+A caller that matched on `SSLError` to detect any end of a session needs an added arm; a `match \exhaustive\` on `SSLState` needs one too. Before:
 
 ```pony
 match session.state()

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,47 @@
+## Add SSL.shutdown
+
+Calling `SSL.shutdown` queues a TLS `close_notify` alert into the session's output BIO. The alert bytes come out through `send`, the same way handshake and application data do.
+
+```pony
+session.shutdown()
+while session.can_send() do
+  transport.write(session.send()?)
+end
+```
+
+Without an alert on the wire before the transport closes, an OpenSSL peer that reads TCP EOF without an alert reports `SSL_R_UNEXPECTED_EOF_WHILE_READING`, its signal for a truncated stream. RFC 8446 §6.1 requires each party to send `close_notify` before closing its write side.
+
+`shutdown` runs from `SSLReady` (initiating) and from `SSLPeerClosed` (reciprocating the peer's alert). If `SSL_shutdown` fails, the session moves to `SSLError` — the caller draining the output BIO sees no bytes and can react instead of closing the transport with silent truncation.
+
+After `shutdown` returns, `write` on the session raises. This package does not offer TLS half-close: application writes after our own or the peer's `close_notify` are refused.
+
+`SSLConnection` does not send `close_notify` on close in either direction — its `closed` hook fires after the transport is gone. A protocol that needs the alert on the wire has to use `SSL` directly.
+
+## Split SSLPeerClosed from SSLError
+
+A session whose peer sent `close_notify` now has state `SSLPeerClosed`. That case used to fold into `SSLError` alongside decryption failures and dropped connections, so a clean end of stream and a failure were indistinguishable.
+
+`SSL.read` on a session in `SSLPeerClosed` still surfaces any bytes decrypted before the peer's `close_notify` — the same way `SSLError` does. The next read past those bytes returns `None`.
+
+`SSL.receive` on a session in `SSLPeerClosed` drops the bytes. `SSL.write` raises, as on any non-`SSLReady` state.
+
+`SSLPeerClosed` is added to the public `SSLState` union. A caller that matched on `SSLError` after `SSL.read` to detect any end of a session needs an added arm; a `match \exhaustive\` on `SSLState` needs an arm for the new variant.
+
+Before:
+
+```pony
+match session.state()
+| SSLReady => None
+| SSLError => // any end of session
+end
+```
+
+After:
+
+```pony
+match session.state()
+| SSLReady => None
+| SSLPeerClosed => // peer closed cleanly
+| SSLError => // decryption failure, syscall error, dropped connection
+end
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
-- Add `SSL.shutdown` for emitting a TLS `close_notify` alert
+- Add `SSL.shutdown` for sending a TLS `close_notify` alert ([PR #147](https://github.com/ponylang/ssl/pull/147))
 
 ### Changed
 
-- Split `SSLPeerClosed` from `SSLError`. A session whose peer sent
-  `close_notify` now reports `SSLPeerClosed`. Callers that matched on
-  `SSLError` after `SSL.read` to detect any end of a session, and any
-  `match \exhaustive\` on `SSLState`, need an added arm for
-  `SSLPeerClosed`.
+- Split `SSLPeerClosed` from `SSLError` on peer `close_notify` ([PR #147](https://github.com/ponylang/ssl/pull/147))
 
 
 ## [3.0.1] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,15 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- Add `SSL.shutdown` for emitting a TLS `close_notify` alert
 
 ### Changed
+
+- Split `SSLPeerClosed` from `SSLError`. A session whose peer sent
+  `close_notify` now reports `SSLPeerClosed`. Callers that matched on
+  `SSLError` after `SSL.read` to detect any end of a session, and any
+  `match \exhaustive\` on `SSLState`, need an added arm for
+  `SSLPeerClosed`.
 
 
 ## [3.0.1] - 2026-08-02

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -45,6 +45,14 @@ actor \nodoc\ Main is TestList
     test(_TestSSLReceiveOnError)
     test(_TestSSLDisposeBeforeHandshake)
     test(_TestSSLDisposeTwice)
+    test(_TestSSLShutdownProducesAlert)
+    test(_TestSSLShutdownReciprocates)
+    test(_TestSSLShutdownAfterDispose)
+    test(_TestSSLShutdownBeforeHandshake)
+    test(_TestSSLWriteAfterShutdownErrors)
+    test(_TestSSLWriteAfterPeerClosedErrors)
+    test(_TestSSLReceiveOnPeerClosed)
+    test(_TestSSLReadAfterPeerClosedReturnsBufferedBytes)
     test(_TestSSLReadAfterDispose)
     test(_TestSSLReadAfterDisposeWithBufferedFrame)
     test(_TestSSLReceiveAfterDispose)
@@ -2666,6 +2674,356 @@ class \nodoc\ iso _TestSSLDisposeTwice is UnitTest
       client.can_send(),
       "can_send() on a disposed session should return false")
 
+    server.dispose()
+
+class \nodoc\ iso _TestSSLShutdownProducesAlert is UnitTest
+  """
+  `shutdown` on a ready session queues a `close_notify` alert into the
+  output BIO. Feeding it to the peer moves the peer's session to
+  `SSLPeerClosed`. An OpenSSL 3.x peer that reads TCP EOF without an alert
+  reports `SSL_R_UNEXPECTED_EOF_WHILE_READING`.
+  """
+  fun name(): String => "net/ssl/SSL.shutdown/produces_alert"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    client.shutdown()
+
+    h.assert_true(
+      client.can_send(),
+      "shutdown() should leave the client with alert bytes to send")
+
+    try
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("could not transfer client's alert to the server")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      server.read() is None,
+      "server.read() should return None after the peer sent close_notify")
+    h.assert_true(
+      server.state() is SSLPeerClosed,
+      "peer close_notify should put the server in SSLPeerClosed")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLShutdownReciprocates is UnitTest
+  """
+  A session that has received the peer's `close_notify` and moved to
+  `SSLPeerClosed` can still call `shutdown` to reciprocate — RFC 8446 §6.1
+  requires each party to send its own alert before closing its write side.
+  The reciprocation queues bytes on the output BIO the same way an
+  initiating `shutdown` does.
+  """
+  fun name(): String => "net/ssl/SSL.shutdown/reciprocates_peer_close"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    client.shutdown()
+
+    try
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("could not transfer client's alert to the server")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      server.read() is None,
+      "server.read() should return None after receiving close_notify")
+    h.assert_true(
+      server.state() is SSLPeerClosed,
+      "server should be in SSLPeerClosed after receiving close_notify")
+
+    server.shutdown()
+
+    h.assert_true(
+      server.can_send(),
+      "shutdown() on SSLPeerClosed should queue the reciprocation alert")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLShutdownAfterDispose is UnitTest
+  """
+  `shutdown` on a disposed session does nothing and does not crash.
+  """
+  fun name(): String => "net/ssl/SSL.shutdown/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    client.dispose()
+    client.shutdown()
+
+    h.assert_true(
+      client.state() is SSLDisposed,
+      "shutdown() on a disposed session should leave state SSLDisposed")
+
+    server.dispose()
+
+class \nodoc\ iso _TestSSLShutdownBeforeHandshake is UnitTest
+  """
+  `shutdown` on a session that has not reached `SSLReady` does nothing.
+  State does not change, and a later `shutdown` on the same session after
+  it handshakes still queues the alert — the pre-handshake call must not
+  have set the internal shutdown flag behind the state guard.
+  """
+  fun name(): String => "net/ssl/SSL.shutdown/before_handshake"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair.fresh(h)?
+      else
+        h.fail("could not create an SSL session pair")
+        return
+      end
+
+    h.assert_true(
+      client.state() is SSLHandshake,
+      "a fresh client session should be in SSLHandshake")
+
+    client.shutdown()
+
+    h.assert_true(
+      client.state() is SSLHandshake,
+      "shutdown() before handshake should not change state")
+
+    // Handshake normally. The pre-handshake shutdown must not have set
+    // `_shutdown_sent` behind the state guard, or the post-handshake
+    // shutdown below would no-op.
+    try
+      _TestSSLSessionPair._handshake(h, client, server)?
+    else
+      h.fail("handshake failed after a pre-handshake shutdown call")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    client.shutdown()
+    h.assert_true(
+      client.can_send(),
+      "shutdown() after a valid handshake should queue alert bytes even "
+        + "after a prior no-op shutdown() from SSLHandshake")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLWriteAfterShutdownErrors is UnitTest
+  """
+  `write` on a session that has called `shutdown` raises, and the session
+  state stays `SSLReady`. Sending after telling the peer we are done
+  writing is a protocol violation. A `write` that reached `SSL_write` would
+  fail and set state to `SSLError`; asserting `SSLReady` proves the raise
+  happened before `SSL_write` ran.
+  """
+  fun name(): String => "net/ssl/SSL.write/after_shutdown"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    client.shutdown()
+
+    try
+      client.write("bytes after shutdown")?
+      h.fail("write() after shutdown() should raise")
+    end
+
+    h.assert_true(
+      client.state() is SSLReady,
+      "write() after shutdown() must raise before reaching SSL_write, "
+        + "leaving state SSLReady")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReadAfterPeerClosedReturnsBufferedBytes is UnitTest
+  """
+  Bytes decrypted before the peer's `close_notify` are still surfaced by a
+  subsequent `read`. The `SSLPeerClosed` transition happens inside `read`
+  when `SSL_read` hits `ZERO_RETURN`; leftover plaintext in the session's
+  read buffer must not be lost.
+
+  This is the same invariant `_TestSSLReadAfterErrorReturnsOnlyDecryptedBytes`
+  covers for `SSLError`, restated for the new state.
+  """
+  fun name(): String => "net/ssl/SSL.read/after_peer_closed_returns_buffered"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    // 50 bytes of application data, then the client's close_notify.
+    try
+      client.write(recover val Array[U8].init('A', 50) end)?
+      _TestSSLTransfer(client, server)?
+      client.shutdown()
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("could not send data plus close_notify")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    // A read(100) buffers the 50 and discovers close_notify on the next
+    // SSL_read, moving state to SSLPeerClosed and returning None.
+    match \exhaustive\ server.read(100)
+    | let data: Array[U8] iso =>
+      h.fail(
+        "50 bytes satisfied a read of 100 and produced "
+          + (consume data).size().string() + " bytes")
+      client.dispose()
+      server.dispose()
+      return
+    | None => None
+    end
+    h.assert_true(
+      server.state() is SSLPeerClosed,
+      "server should be in SSLPeerClosed after reading close_notify")
+
+    // A read(50) after the peer close must surface the 50 buffered bytes.
+    match \exhaustive\ server.read(50)
+    | let data: Array[U8] iso =>
+      h.assert_array_eq[U8](
+        recover val Array[U8].init('A', 50) end,
+        consume data,
+        "a read of 50 returned something other than the 50 decrypted bytes")
+    | None =>
+      h.fail("a read of 50 returned none of the 50 buffered bytes")
+    end
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLWriteAfterPeerClosedErrors is UnitTest
+  """
+  `write` on a session in `SSLPeerClosed` raises and leaves state at
+  `SSLPeerClosed`. Reaching `SSL_write` would set state to `SSLError`, so
+  the unchanged state confirms the raise came from the state guard.
+  """
+  fun name(): String => "net/ssl/SSL.write/after_peer_closed"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    client.shutdown()
+    try
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("could not transfer client's alert to the server")
+      client.dispose()
+      server.dispose()
+      return
+    end
+    h.assert_true(
+      server.read() is None,
+      "server.read() should return None after receiving close_notify")
+    h.assert_true(
+      server.state() is SSLPeerClosed,
+      "server should be in SSLPeerClosed")
+
+    try
+      server.write("half-close write")?
+      h.fail("write() on SSLPeerClosed should raise")
+    end
+
+    h.assert_true(
+      server.state() is SSLPeerClosed,
+      "write() raise on SSLPeerClosed should leave state SSLPeerClosed")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestSSLReceiveOnPeerClosed is UnitTest
+  """
+  `receive` on a session in `SSLPeerClosed` drops the bytes. Ciphertext
+  arriving after the peer's `close_notify` is not application data the
+  session can decrypt or use.
+  """
+  fun name(): String => "net/ssl/SSL.receive/on_peer_closed"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestSSLSessionPair(h)?
+      else
+        h.fail("could not establish an SSL session pair")
+        return
+      end
+
+    client.shutdown()
+    try
+      _TestSSLTransfer(client, server)?
+    else
+      h.fail("could not transfer client's alert to the server")
+      client.dispose()
+      server.dispose()
+      return
+    end
+    h.assert_true(
+      server.read() is None,
+      "server.read() should return None after receiving close_notify")
+    h.assert_true(
+      server.state() is SSLPeerClosed,
+      "server should be in SSLPeerClosed")
+
+    server.receive("bytes past close_notify")
+
+    h.assert_true(
+      server.state() is SSLPeerClosed,
+      "receive() on SSLPeerClosed should not change state")
+    h.assert_true(
+      server.read() is None,
+      "read() on SSLPeerClosed after garbage receive should still return None")
+
+    client.dispose()
     server.dispose()
 
 class \nodoc\ iso _TestSSLReadAfterDispose is UnitTest

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -18,6 +18,7 @@ use @SSL_set_bio[None](
 use @SSL_set_accept_state[None](ssl: Pointer[_SSL])
 use @SSL_set_connect_state[None](ssl: Pointer[_SSL])
 use @SSL_do_handshake[I32](ssl: Pointer[_SSL])
+use @SSL_shutdown[I32](ssl: Pointer[_SSL])
 use @SSL_get0_alpn_selected[None](
   ssl: Pointer[_SSL] tag,
   data: Pointer[Pointer[U8] iso],
@@ -125,15 +126,35 @@ primitive SSLAuthFail
 primitive SSLReady
   """
   The handshake is complete. Application data can be sent and received.
+  A session that has called `shutdown` stays in `SSLReady` but errors on
+  `write`.
   """
 
 primitive SSLError
   """
-  The session failed for a reason other than the one `SSLAuthFail` names. A
-  session reports this when its peer did not speak TLS, shared no protocol
-  version, rejected the certificate the session presented, or presented one
-  that would not parse. A session created with verification off reports it for
-  every failure, and so does any session that fails after its handshake.
+  The session failed for a reason other than the ones `SSLAuthFail` and
+  `SSLPeerClosed` name. A session reports this when its peer did not speak
+  TLS, shared no protocol version, rejected the certificate the session
+  presented, or presented one that would not parse. A session created with
+  verification off reports it for every failure, and so does any session
+  that fails after its handshake.
+  """
+
+primitive SSLPeerClosed
+  """
+  The peer sent `close_notify`. No more application data will arrive on
+  this session, and the session has not failed. `read` still surfaces
+  bytes decrypted before the alert, and returns `None` past those.
+  `receive` does nothing. `write` errors. `can_send`, `send`, and
+  `shutdown` still work, so a caller can reciprocate with its own alert.
+
+  `write` erroring on this state means TLS half-close (writing more
+  application data after the peer's `close_notify`) is not supported.
+
+  A session ends up here only from `read`; `receive` and the handshake
+  path never move a session to this state. A `shutdown` from here that
+  fails moves the session to `SSLError` — the reciprocal alert did not
+  go out.
   """
 
 primitive SSLDisposed
@@ -144,12 +165,20 @@ primitive SSLDisposed
   """
 
 type SSLState is
-  (SSLHandshake | SSLAuthFail | SSLReady | SSLError | SSLDisposed)
+  ( SSLHandshake
+  | SSLAuthFail
+  | SSLReady
+  | SSLError
+  | SSLPeerClosed
+  | SSLDisposed
+  )
   """
   The state of an SSL session. A session starts in `SSLHandshake` and reaches
   `SSLReady`, `SSLAuthFail`, or `SSLError` from there. A ready session can
-  still fail into `SSLError` later. Disposing a session puts it in
-  `SSLDisposed` from any state, and it stays there.
+  reach `SSLPeerClosed` (peer sent `close_notify`) or fail into `SSLError`
+  later. A session in `SSLPeerClosed` can fail into `SSLError` on a
+  reciprocation `shutdown`. Disposing a session puts it in `SSLDisposed`
+  from any state, and it stays there.
   """
 
 class SSL
@@ -169,6 +198,7 @@ class SSL
   var _output: Pointer[_BIO] tag = Pointer[_BIO]
   var _state: SSLState = SSLHandshake
   var _read_buf: Array[U8] iso = []
+  var _shutdown_sent: Bool = false
 
   new _create(
     context: SSLContext val,
@@ -259,6 +289,11 @@ class SSL
     non-zero, this returns `None` until at least `expect` bytes are available,
     then returns everything it holds, which is at least `expect`. Returns
     `None` when the session has been disposed or is in `SSLAuthFail`.
+
+    A session in `SSLPeerClosed` still surfaces any bytes decrypted before
+    the peer's `close_notify` arrived — the same way `SSLError` does. Past
+    those bytes, `read` returns `None` and leaves the session in
+    `SSLPeerClosed`.
     """
     if _ssl.is_null() then return None end
     if _state is SSLAuthFail then return None end
@@ -293,9 +328,11 @@ class SSL
     if r <= 0 then
       match @SSL_get_error(_ssl, r)
       | _SSLErrorCode.ssl()
-      | _SSLErrorCode.syscall()
-      | _SSLErrorCode.zero_return() =>
+      | _SSLErrorCode.syscall() =>
         _state = SSLError
+        return None
+      | _SSLErrorCode.zero_return() =>
+        _state = SSLPeerClosed
         return None
       | _SSLErrorCode.want_read() =>
         return None
@@ -338,11 +375,13 @@ class SSL
   fun ref write(data: ByteSeq) ? =>
     """
     When application data is sent, add it to the SSL session. Does nothing if
-    the session has been disposed. Raises an error if the handshake is not
-    complete or if `SSL_write` does not encrypt the data.
+    the session has been disposed. Raises when the session is not `SSLReady`
+    (still handshaking, ended in `SSLAuthFail`, `SSLError`, or `SSLPeerClosed`),
+    when `shutdown` has been called, or when `SSL_write` does not encrypt the
+    data.
     """
     if _ssl.is_null() then return end
-    if _state isnt SSLReady then error end
+    if (_state isnt SSLReady) or _shutdown_sent then error end
 
     let total = data.size()
     if total > 0 then
@@ -372,10 +411,16 @@ class SSL
   fun ref receive(data: ByteSeq) =>
     """
     When data is received, add it to the SSL session. Does nothing when the
-    session has been disposed or is in `SSLAuthFail` or `SSLError`.
+    session has been disposed or is in `SSLAuthFail`, `SSLError`, or
+    `SSLPeerClosed`.
     """
     if _ssl.is_null() then return end
-    if (_state is SSLAuthFail) or (_state is SSLError) then return end
+    if (_state is SSLAuthFail)
+      or (_state is SSLError)
+      or (_state is SSLPeerClosed)
+    then
+      return
+    end
 
     let total = data.size()
     if total > 0 then
@@ -417,6 +462,42 @@ class SSL
     if r <= 0 then error end
     buf.truncate(r.usize())
     buf
+
+  fun ref shutdown() =>
+    """
+    Queue a TLS `close_notify` alert. `can_send` and `send` then hand back
+    the bytes to pass to the destination. Runs from `SSLReady` (initiating)
+    and `SSLPeerClosed` (reciprocating the peer's alert). Does nothing when
+    the session has been disposed, is in any other state, or has already
+    been shut down. Moves state to `SSLError` on a hard failure.
+
+    RFC 8446 §6.1: each party sends `close_notify` before closing its write
+    side. An OpenSSL peer that reads TCP EOF without an alert reports
+    `SSL_R_UNEXPECTED_EOF_WHILE_READING`, its signal for a truncated stream.
+
+    After this returns, `write` on this session errors. This package does
+    not offer TLS half-close: a session whose peer sent `close_notify`
+    cannot write either — see `SSLPeerClosed`.
+    """
+    if _ssl.is_null() then return end
+    if (_state isnt SSLReady) and (_state isnt SSLPeerClosed) then return end
+    if _shutdown_sent then return end
+    @ERR_clear_error()
+    let r = @SSL_shutdown(_ssl)
+    _shutdown_sent = true
+
+    if r < 0 then
+      match @SSL_get_error(_ssl, r)
+      | _SSLErrorCode.ssl()
+      | _SSLErrorCode.syscall()
+      | _SSLErrorCode.zero_return() =>
+        _state = SSLError
+      | _SSLErrorCode.want_read() =>
+        None
+      else
+        _Unreachable()
+      end
+    end
 
   fun ref dispose() =>
     """

--- a/ssl/net/ssl.pony
+++ b/ssl/net/ssl.pony
@@ -126,35 +126,23 @@ primitive SSLAuthFail
 primitive SSLReady
   """
   The handshake is complete. Application data can be sent and received.
-  A session that has called `shutdown` stays in `SSLReady` but errors on
-  `write`.
   """
 
 primitive SSLError
   """
-  The session failed for a reason other than the ones `SSLAuthFail` and
-  `SSLPeerClosed` name. A session reports this when its peer did not speak
-  TLS, shared no protocol version, rejected the certificate the session
-  presented, or presented one that would not parse. A session created with
-  verification off reports it for every failure, and so does any session
-  that fails after its handshake.
+  The session failed for a reason other than the one `SSLAuthFail` names. A
+  session reports this when its peer did not speak TLS, shared no protocol
+  version, rejected the certificate the session presented, or presented one
+  that would not parse. A session created with verification off reports it for
+  every failure, and so does any session that fails after its handshake.
   """
 
 primitive SSLPeerClosed
   """
   The peer sent `close_notify`. No more application data will arrive on
-  this session, and the session has not failed. `read` still surfaces
-  bytes decrypted before the alert, and returns `None` past those.
-  `receive` does nothing. `write` errors. `can_send`, `send`, and
-  `shutdown` still work, so a caller can reciprocate with its own alert.
-
-  `write` erroring on this state means TLS half-close (writing more
-  application data after the peer's `close_notify`) is not supported.
-
-  A session ends up here only from `read`; `receive` and the handshake
-  path never move a session to this state. A `shutdown` from here that
-  fails moves the session to `SSLError` — the reciprocal alert did not
-  go out.
+  this session, and the session has not failed. `read` still surfaces any
+  bytes decrypted before the alert. `write` errors — this package does
+  not support TLS half-close. `shutdown` reciprocates.
   """
 
 primitive SSLDisposed
@@ -175,10 +163,8 @@ type SSLState is
   """
   The state of an SSL session. A session starts in `SSLHandshake` and reaches
   `SSLReady`, `SSLAuthFail`, or `SSLError` from there. A ready session can
-  reach `SSLPeerClosed` (peer sent `close_notify`) or fail into `SSLError`
-  later. A session in `SSLPeerClosed` can fail into `SSLError` on a
-  reciprocation `shutdown`. Disposing a session puts it in `SSLDisposed`
-  from any state, and it stays there.
+  reach `SSLPeerClosed` or fail into `SSLError` later. Disposing a session
+  puts it in `SSLDisposed` from any state, and it stays there.
   """
 
 class SSL
@@ -289,11 +275,6 @@ class SSL
     non-zero, this returns `None` until at least `expect` bytes are available,
     then returns everything it holds, which is at least `expect`. Returns
     `None` when the session has been disposed or is in `SSLAuthFail`.
-
-    A session in `SSLPeerClosed` still surfaces any bytes decrypted before
-    the peer's `close_notify` arrived — the same way `SSLError` does. Past
-    those bytes, `read` returns `None` and leaves the session in
-    `SSLPeerClosed`.
     """
     if _ssl.is_null() then return None end
     if _state is SSLAuthFail then return None end
@@ -375,10 +356,9 @@ class SSL
   fun ref write(data: ByteSeq) ? =>
     """
     When application data is sent, add it to the SSL session. Does nothing if
-    the session has been disposed. Raises when the session is not `SSLReady`
-    (still handshaking, ended in `SSLAuthFail`, `SSLError`, or `SSLPeerClosed`),
-    when `shutdown` has been called, or when `SSL_write` does not encrypt the
-    data.
+    the session has been disposed. Raises when the session is not `SSLReady`,
+    when `shutdown` has been called, or when `SSL_write` does not encrypt
+    the data.
     """
     if _ssl.is_null() then return end
     if (_state isnt SSLReady) or _shutdown_sent then error end

--- a/ssl/net/ssl_connection.pony
+++ b/ssl/net/ssl_connection.pony
@@ -11,6 +11,13 @@ class SSLConnection is TCPConnectionNotify
   nothing at all when the session is in `SSLError`. The connection closes on
   either failure. `SSLAuthFail` and `SSLError` each list the failures they
   cover.
+
+  A peer that sends `close_notify` moves the session to `SSLPeerClosed` and
+  the wrapper closes the connection — `closed` reaches the wrapped protocol,
+  `auth_failed` does not. This wrapper does not send `close_notify` on close
+  in either direction: application-initiated close fires `closed` after the
+  socket is gone, and peer-initiated close does not reciprocate. A protocol
+  that needs the alert on the wire has to use `SSL` directly.
   """
   let _notify: TCPConnectionNotify
   let _ssl: SSL
@@ -180,6 +187,12 @@ class SSLConnection is TCPConnectionNotify
 
       return true
     | SSLError =>
+      if not _closed then
+        conn.close()
+      end
+
+      return true
+    | SSLPeerClosed =>
       if not _closed then
         conn.close()
       end

--- a/ssl/net/ssl_connection.pony
+++ b/ssl/net/ssl_connection.pony
@@ -12,12 +12,8 @@ class SSLConnection is TCPConnectionNotify
   either failure. `SSLAuthFail` and `SSLError` each list the failures they
   cover.
 
-  A peer that sends `close_notify` moves the session to `SSLPeerClosed` and
-  the wrapper closes the connection — `closed` reaches the wrapped protocol,
-  `auth_failed` does not. This wrapper does not send `close_notify` on close
-  in either direction: application-initiated close fires `closed` after the
-  socket is gone, and peer-initiated close does not reciprocate. A protocol
-  that needs the alert on the wire has to use `SSL` directly.
+  This wrapper does not send `close_notify` on close. A protocol that
+  needs the alert on the wire has to use `SSL` directly.
   """
   let _notify: TCPConnectionNotify
   let _ssl: SSL


### PR DESCRIPTION
Adds the primitive that ponylang/lori#348 needs — a way to emit `close_notify` before closing the transport — and separates a clean peer close from a session failure.

## Parked items

Please weigh in before merge:

1. **Version bump: 3.1.0 vs 4.0.0.** Adding a variant to `SSLState` breaks exhaustive matches. When `SSLDisposed` was added in 3.0.0 it was labeled a major bump. I've structured the CHANGELOG to warrant the same, but the release-notes wording doesn't yet name a version.

2. **`_shutdown_sent: Bool` vs a state variant.** The flag blocks `write` after `shutdown` was called from `SSLReady`. Promoting it to an `SSLShutdownSent` (or similar) state variant would satisfy design principle #11 more cleanly, but adds a second exhaustive-match breakage in one release. Kept as a bool for now. Also worth noting: the `state-machine-137` WIP branch is doing exactly the "state carries all behavior; no per-state booleans" restructure this bool cuts against — reconciliation with that work will be design work, not a mechanical rebase.

3. **`SSLConnection` outbound `close_notify` deferred.** `SSLConnection.closed` fires after the transport is gone, so the wrapper can't send `close_notify` on either application-initiated close (no hook before close) or peer-initiated close (no reachable state observation from `_poll` without moving the reciprocation into the read loop, which needs an integration test I didn't build here). Documented in the wrapper's class docstring and in the release notes; a follow-up will address it with a test-driven design.
