### PR TITLE
Add DTLSContext and DTLS for datagram TLS

### DIFF
--- a/.release-notes/add-dtls-support.md
+++ b/.release-notes/add-dtls-support.md
@@ -1,0 +1,40 @@
+## Add DTLSContext and DTLS for datagram TLS
+
+`DTLSContext` and `DTLS` bring DTLS (datagram TLS) support. DTLS provides the same authentication and encryption as TLS over unreliable transports like UDP.
+
+The API mirrors `SSLContext` and `SSL`. A `DTLSContext` creates client or server `DTLS` sessions; the session encrypts and decrypts application data through `write`, `read`, `receive`, and `send`, with the same return types (`SSLReceiveResult`, `SSLReadResult`).
+
+```pony
+let ctx = recover val
+  let c = DTLSContext
+  c.set_cert(
+    FilePath(auth, "cert.pem"),
+    FilePath(auth, "key.pem"))?
+  c.set_authority(FilePath(auth, "ca.pem"))?
+  c.set_client_verify(true)
+  c
+end
+
+let session = ctx.client("server.example.com")?
+
+// Feed encrypted bytes from the network into the session
+match session.receive(data_from_udp)
+| SSLReady => None // handshake complete
+| SSLAccepted => None // still handshaking
+| SSLAuthFail => // peer certificate rejected
+| SSLError => // protocol error
+end
+
+// Encrypt application data for sending
+session.write("hello")?
+match session.send()
+| let out: Array[U8] iso => send_over_udp(consume out)
+end
+
+// Read decrypted application data
+match session.read()
+| let plaintext: Array[U8] iso => // use it
+end
+```
+
+`DTLSContext` and `SSLContext` are separate types because a TLS context cannot create a DTLS session and vice versa. Using separate types makes the wrong combination a compile error.

--- a/ssl/net/_dtls_failed_state.pony
+++ b/ssl/net/_dtls_failed_state.pony
@@ -1,0 +1,31 @@
+trait _DTLSFailedState is _DTLSSessionState
+  """
+  Shared defaults for `_DTLSAuthFailed` and `_DTLSErrored`. The session has
+  failed but the OpenSSL handle is still live.
+  """
+
+  fun ref read(dtls: DTLS ref, expect: USize): SSLReadResult =>
+    match \exhaustive\ dtls._drain_read_buf(expect)
+    | let data: Array[U8] iso => consume data
+    | None => SSLError
+    end
+
+  fun ref write(dtls: DTLS ref, data: ByteSeq) ? => error
+
+  fun ref close(dtls: DTLS ref) => None
+
+  fun ref send(dtls: DTLS ref): (Array[U8] iso^ | None) => dtls._do_send()
+
+  fun alpn_selected(dtls: DTLS box): (ALPNProtocolName | None) => None
+
+  fun ref dispose(dtls: DTLS ref) =>
+    dtls._do_dispose()
+    dtls._set_state(_DTLSDisposed)
+
+class _DTLSAuthFailed is _DTLSFailedState
+  fun ref receive(dtls: DTLS ref, data: ByteSeq): SSLReceiveResult =>
+    SSLAuthFail
+
+class _DTLSErrored is _DTLSFailedState
+  fun ref receive(dtls: DTLS ref, data: ByteSeq): SSLReceiveResult =>
+    SSLError

--- a/ssl/net/_dtls_session_state.pony
+++ b/ssl/net/_dtls_session_state.pony
@@ -1,0 +1,131 @@
+trait _DTLSSessionState
+  fun ref receive(dtls: DTLS ref, data: ByteSeq): SSLReceiveResult
+  fun ref read(dtls: DTLS ref, expect: USize): SSLReadResult
+  fun ref write(dtls: DTLS ref, data: ByteSeq) ?
+  fun ref close(dtls: DTLS ref)
+  fun ref send(dtls: DTLS ref): (Array[U8] iso^ | None)
+  fun alpn_selected(dtls: DTLS box): (ALPNProtocolName | None)
+  fun ref dispose(dtls: DTLS ref)
+
+class _DTLSHandshaking is _DTLSSessionState
+  fun ref receive(dtls: DTLS ref, data: ByteSeq): SSLReceiveResult =>
+    dtls._do_receive(data)
+    dtls._kick_handshake()
+
+  fun ref read(dtls: DTLS ref, expect: USize): SSLReadResult => None
+
+  fun ref write(dtls: DTLS ref, data: ByteSeq) ? => error
+
+  fun ref close(dtls: DTLS ref) => None
+
+  fun ref send(dtls: DTLS ref): (Array[U8] iso^ | None) => dtls._do_send()
+
+  fun alpn_selected(dtls: DTLS box): (ALPNProtocolName | None) => None
+
+  fun ref dispose(dtls: DTLS ref) =>
+    dtls._do_dispose()
+    dtls._set_state(_DTLSDisposed)
+
+class _DTLSReady is _DTLSSessionState
+  fun ref receive(dtls: DTLS ref, data: ByteSeq): SSLReceiveResult =>
+    dtls._do_receive(data)
+    SSLAccepted
+
+  fun ref read(dtls: DTLS ref, expect: USize): SSLReadResult =>
+    dtls._do_read(expect)
+
+  fun ref write(dtls: DTLS ref, data: ByteSeq) ? =>
+    dtls._do_write(data)?
+
+  fun ref close(dtls: DTLS ref) =>
+    dtls._do_close_notify()
+
+  fun ref send(dtls: DTLS ref): (Array[U8] iso^ | None) => dtls._do_send()
+
+  fun alpn_selected(dtls: DTLS box): (ALPNProtocolName | None) =>
+    dtls._do_alpn_selected()
+
+  fun ref dispose(dtls: DTLS ref) =>
+    dtls._do_dispose()
+    dtls._set_state(_DTLSDisposed)
+
+class _DTLSClosing is _DTLSSessionState
+  """
+  The peer sent `close_notify`; we have not responded yet.
+  """
+
+  fun ref receive(dtls: DTLS ref, data: ByteSeq): SSLReceiveResult =>
+    dtls._do_receive(data)
+    SSLAccepted
+
+  fun ref read(dtls: DTLS ref, expect: USize): SSLReadResult =>
+    match \exhaustive\ dtls._do_read(expect)
+    | let data: Array[U8] iso => consume data
+    | None => SSLClosed
+    | SSLClosed => SSLClosed
+    | SSLError => SSLError
+    | InvalidOperation => _Unreachable(); SSLError
+    end
+
+  fun ref write(dtls: DTLS ref, data: ByteSeq) ? => error
+
+  fun ref close(dtls: DTLS ref) =>
+    dtls._do_close_notify()
+
+  fun ref send(dtls: DTLS ref): (Array[U8] iso^ | None) => dtls._do_send()
+
+  fun alpn_selected(dtls: DTLS box): (ALPNProtocolName | None) =>
+    dtls._do_alpn_selected()
+
+  fun ref dispose(dtls: DTLS ref) =>
+    dtls._do_dispose()
+    dtls._set_state(_DTLSDisposed)
+
+class _DTLSClosed is _DTLSSessionState
+  """
+  We have sent our `close_notify`.
+  """
+
+  fun ref receive(dtls: DTLS ref, data: ByteSeq): SSLReceiveResult =>
+    dtls._do_receive(data)
+    SSLAccepted
+
+  fun ref read(dtls: DTLS ref, expect: USize): SSLReadResult =>
+    let result = dtls._do_read(expect)
+    dtls._restore_closed_unless_errored(this)
+    match \exhaustive\ consume result
+    | let data: Array[U8] iso => consume data
+    | None => SSLClosed
+    | SSLClosed => SSLClosed
+    | SSLError => SSLError
+    | InvalidOperation => _Unreachable(); SSLError
+    end
+
+  fun ref write(dtls: DTLS ref, data: ByteSeq) ? => error
+
+  fun ref close(dtls: DTLS ref) => None
+
+  fun ref send(dtls: DTLS ref): (Array[U8] iso^ | None) => dtls._do_send()
+
+  fun alpn_selected(dtls: DTLS box): (ALPNProtocolName | None) =>
+    dtls._do_alpn_selected()
+
+  fun ref dispose(dtls: DTLS ref) =>
+    dtls._do_dispose()
+    dtls._set_state(_DTLSDisposed)
+
+class _DTLSDisposed is _DTLSSessionState
+  fun ref receive(dtls: DTLS ref, data: ByteSeq): SSLReceiveResult =>
+    InvalidOperation
+
+  fun ref read(dtls: DTLS ref, expect: USize): SSLReadResult => InvalidOperation
+
+  fun ref write(dtls: DTLS ref, data: ByteSeq) => None
+
+  fun ref close(dtls: DTLS ref) => None
+
+  fun ref send(dtls: DTLS ref): (Array[U8] iso^ | None) => None
+
+  fun alpn_selected(dtls: DTLS box): (ALPNProtocolName | None) => None
+
+  fun ref dispose(dtls: DTLS ref) => None

--- a/ssl/net/_test.pony
+++ b/ssl/net/_test.pony
@@ -90,6 +90,39 @@ actor \nodoc\ Main is TestList
     test(_TestSSLContextAllowTLSV1u2)
     test(_TestSSLContextClientAfterDispose)
     test(_TestSSLContextServerAfterDispose)
+    test(_TestDTLSHandshakeInMemory)
+    test(_TestDTLSReceiveUntrustedChain)
+    test(_TestDTLSReceiveVerifyOffNeverAuthFails)
+    test(_TestDTLSReceiveHostnameMismatch)
+    test(_TestDTLSDisposeBeforeHandshake)
+    test(_TestDTLSDisposeTwice)
+    test(_TestDTLSReadAfterDispose)
+    test(_TestDTLSReceiveAfterDispose)
+    test(_TestDTLSContextDisposeTwice)
+    test(_TestDTLSContextClientAfterDispose)
+    test(_TestDTLSContextServerAfterDispose)
+    test(_TestDTLSContextSetMinProtoVersionAfterDispose)
+    test(_TestDTLSContextSetMaxProtoVersionAfterDispose)
+    test(_TestDTLSContextSetAuthorityAfterDispose)
+    test(_TestDTLSContextSetCertAfterDispose)
+    test(_TestDTLSContextSetCiphersAfterDispose)
+    test(_TestDTLSContextSetVerifyDepthAfterDispose)
+    test(_TestDTLSContextALPNSetResolverAfterDispose)
+    test(_TestDTLSContextALPNSetClientProtocolsAfterDispose)
+    test(_TestDTLSWriteAfterDispose)
+    test(_TestDTLSSendAfterDisposeReturnsNone)
+    test(_TestDTLSReadAfterDisposeWithBufferedFrame)
+    test(_TestDTLSReadOnAuthFail)
+    test(_TestDTLSReceiveOnAuthFail)
+    test(_TestDTLSSendOnFailedSession)
+    test(_TestDTLSCloseFromReady)
+    test(_TestDTLSCloseIdempotent)
+    test(_TestDTLSCloseFromWrongStates)
+    test(_TestDTLSCloseAfterDispose)
+    test(_TestDTLSPeerCloseNotifyDetected)
+    test(_TestDTLSWriteBlockedInClosed)
+    test(_TestDTLSBidirectionalCloseRoundtrip)
+    test(_TestDTLSWriteBlockedInClosing)
     test(_TestTCPSSLWritev)
     test(_TestTCPSSLExpect)
     test(_TestTCPSSLMute)
@@ -4737,3 +4770,1158 @@ class \nodoc\ iso _TestMatchNameWildcardInsufficientLevels is UnitTest
     h.assert_false(X509._match_name("example.com", "*."))
     // Wildcard followed by dot-dot is not valid
     h.assert_false(X509._match_name("foo.example.com", "*..com"))
+
+primitive \nodoc\ _TestDTLSContext
+  fun val apply(
+    h: TestHelper,
+    cert: Bool = false,
+    authority: Bool = false,
+    client_verify: Bool = true,
+    server_verify: Bool = false)
+    : DTLSContext val ?
+  =>
+    let auth = FileAuth(h.env.root)
+
+    try
+      recover val
+        let ctx: DTLSContext ref = DTLSContext
+        if cert then
+          ctx.set_cert(
+            FilePath(auth, "assets/cert.pem"),
+            FilePath(auth, "assets/key.pem"))?
+        end
+        if authority then
+          ctx.set_authority(FilePath(auth, "assets/cert.pem"))?
+        end
+        ctx.set_client_verify(client_verify)
+        ctx.set_server_verify(server_verify)
+        ctx
+      end
+    else
+      h.fail("dtls context setup failed")
+      error
+    end
+
+primitive \nodoc\ _TestDTLSDefaultSessions
+  fun val apply(h: TestHelper): (DTLS iso^, DTLS iso^) ? =>
+    let dtlsctx =
+      _TestDTLSContext(
+        h
+        where cert = true,
+          authority = true,
+          client_verify = false,
+          server_verify = false)?
+
+    let dtls_client =
+      try
+        dtlsctx.client()?
+      else
+        h.fail("failed getting dtls client session")
+        error
+      end
+    let dtls_server =
+      try
+        dtlsctx.server()?
+      else
+        h.fail("failed getting dtls server session")
+        error
+      end
+
+    (consume dtls_client, consume dtls_server)
+
+primitive \nodoc\ _TestDTLSTransfer
+  fun val apply(sender: DTLS, receiver: DTLS): SSLReceiveResult =>
+    var result: SSLReceiveResult = SSLAccepted
+    while true do
+      match \exhaustive\ sender.send()
+      | let data: Array[U8] iso =>
+        result = receiver.receive(consume data)
+      | None => break
+      end
+    end
+    result
+
+primitive \nodoc\ _TestDTLSSessionPair
+  fun val apply(h: TestHelper): (DTLS, DTLS) ? =>
+    (let client, let server) = fresh(h)?
+    _handshake(h, client, server)?
+    (client, server)
+
+  fun val fresh(h: TestHelper): (DTLS, DTLS) ? =>
+    (let client_session, let server_session) = _TestDTLSDefaultSessions(h)?
+    let client: DTLS = consume client_session
+    let server: DTLS = consume server_session
+    (client, server)
+
+  fun val attempt(
+    h: TestHelper,
+    client_ctx: DTLSContext val,
+    server_ctx: DTLSContext val,
+    hostname: String = "")
+    : (DTLS, DTLS, SSLReceiveResult, SSLReceiveResult) ?
+  =>
+    let client: DTLS =
+      try
+        client_ctx.client(hostname)?
+      else
+        h.fail("failed getting dtls client session")
+        error
+      end
+    let server: DTLS =
+      try
+        server_ctx.server()?
+      else
+        h.fail("failed getting dtls server session")
+        client.dispose()
+        error
+      end
+    (let cr, let sr) = _pump(client, server)
+    (client, server, cr, sr)
+
+  fun val _pump(
+    client: DTLS,
+    server: DTLS)
+    : (SSLReceiveResult, SSLReceiveResult)
+  =>
+    var rounds: USize = 0
+    var client_result: SSLReceiveResult = SSLAccepted
+    var server_result: SSLReceiveResult = SSLAccepted
+
+    while
+      ((client_result is SSLAccepted) or (server_result is SSLAccepted))
+        and (rounds < _max_rounds())
+    do
+      rounds = rounds + 1
+      let sr = _TestDTLSTransfer(client, server)
+      let cr = _TestDTLSTransfer(server, client)
+      if not (sr is SSLAccepted) then server_result = sr end
+      if not (cr is SSLAccepted) then client_result = cr end
+    end
+
+    (client_result, server_result)
+
+  fun val _max_rounds(): USize => 20
+
+  fun val _handshake(h: TestHelper, client: DTLS, server: DTLS) ? =>
+    (let cr, let sr) = _pump(client, server)
+
+    if (cr is SSLAccepted) or (sr is SSLAccepted) then
+      h.fail("in memory DTLS handshake did not finish")
+      error
+    end
+
+    if (cr isnt SSLReady) or (sr isnt SSLReady) then
+      h.fail("in memory DTLS handshake did not reach SSLReady")
+      error
+    end
+
+class \nodoc\ iso _TestDTLSHandshakeInMemory is UnitTest
+  """
+  Two DTLS sessions can complete a handshake with no transport between them by
+  handing each side's outgoing bytes straight to the other, and application
+  data written by one can be read by the other.
+  """
+  fun name(): String => "net/dtls/DTLS/handshake_in_memory"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    try
+      client.write("hello")?
+      _TestDTLSTransfer(client, server)
+    else
+      h.fail("client could not send application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    match \exhaustive\ server.read()
+    | let data: Array[U8] iso =>
+      h.assert_eq[String]("hello", String.from_array(consume data))
+    | None => h.fail("server read no application data")
+    | SSLClosed => h.fail("server read returned SSLClosed")
+    | SSLError => h.fail("server read returned SSLError")
+    | InvalidOperation => h.fail("server read returned InvalidOperation")
+    end
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSReceiveUntrustedChain is UnitTest
+  """
+  A verifying DTLS session whose peer presents a chain it does not trust
+  reports `SSLAuthFail`.
+  """
+  fun name(): String => "net/dtls/DTLS.receive/untrusted_chain"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server, let cr, _) =
+      try
+        _TestDTLSSessionPair.attempt(
+          h,
+          _TestDTLSContext(h where client_verify = true)?,
+          _TestDTLSContext(h where cert = true)?)?
+      else
+        h.fail("could not create a DTLS session pair")
+        return
+      end
+
+    h.assert_true(
+      cr is SSLAuthFail,
+      "a chain the client does not trust should report SSLAuthFail")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSReceiveVerifyOffNeverAuthFails is UnitTest
+  """
+  A DTLS session created with verification off reports `SSLError` when its
+  handshake fails, not `SSLAuthFail`.
+  """
+  fun name(): String => "net/dtls/DTLS.receive/verify_off_never_auth_fails"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server, let cr, _) =
+      try
+        _TestDTLSSessionPair.attempt(
+          h,
+          _TestDTLSContext(h where client_verify = false)?,
+          _TestDTLSContext(
+            h where cert = true, authority = true, server_verify = true)?)?
+      else
+        h.fail("could not create a DTLS session pair")
+        return
+      end
+
+    h.assert_true(
+      (cr is SSLError) or (cr is SSLReady),
+      "a session that was not asked to verify should not report SSLAuthFail")
+
+    h.assert_false(
+      cr is SSLAuthFail,
+      "a session that was not asked to verify should never report SSLAuthFail")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSReceiveHostnameMismatch is UnitTest
+  """
+  A verifying DTLS session whose peer presents a certificate that is not valid
+  for the hostname reports `SSLAuthFail`.
+  """
+  fun name(): String => "net/dtls/DTLS.receive/hostname_mismatch"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server, let cr, _) =
+      try
+        let client_ctx =
+          _TestDTLSContext(h where authority = true, client_verify = true)?
+        let server_ctx = _TestDTLSContext(h where cert = true)?
+        _TestDTLSSessionPair.attempt(
+          h, client_ctx, server_ctx where hostname = "nomatch.example.com")?
+      else
+        h.fail("could not create a DTLS session pair")
+        return
+      end
+
+    h.assert_true(
+      cr is SSLAuthFail,
+      "a certificate not valid for the hostname should report SSLAuthFail")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSDisposeBeforeHandshake is UnitTest
+  """
+  A session disposed before its handshake finishes is inert: `read` returns
+  `InvalidOperation`, `send` returns `None`, and `receive` returns
+  `InvalidOperation`.
+
+  A fresh client session has a ClientHello waiting to go out, so `send`
+  returning `None` after the dispose is the disposed check and not an empty
+  BIO.
+  """
+  fun name(): String => "net/dtls/DTLS.dispose/before_handshake"
+
+  fun apply(h: TestHelper) =>
+    let dtlsctx =
+      try
+        _TestDTLSContext(
+          h
+          where cert = true,
+            authority = true,
+            client_verify = false,
+            server_verify = false)?
+      else
+        return
+      end
+
+    let client =
+      try
+        dtlsctx.client()?
+      else
+        h.fail("failed getting dtls client session")
+        return
+      end
+
+    h.assert_true(
+      client.send() isnt None,
+      "a fresh client session should have a ClientHello to send")
+
+    client.dispose()
+
+    h.assert_true(
+      client.read() is InvalidOperation,
+      "read() on a disposed session should return InvalidOperation")
+    h.assert_true(
+      client.send() is None,
+      "send() on a disposed session should return None")
+    h.assert_true(
+      client.receive("bytes that will never be decrypted") is InvalidOperation,
+      "receive on a disposed session should return InvalidOperation")
+
+class \nodoc\ iso _TestDTLSDisposeTwice is UnitTest
+  """
+  Disposing a DTLS session twice does not crash.
+  """
+  fun name(): String => "net/dtls/DTLS.dispose/twice"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.dispose()
+    client.dispose()
+    server.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSReadAfterDispose is UnitTest
+  """
+  Reading from a disposed DTLS session returns `InvalidOperation`.
+  """
+  fun name(): String => "net/dtls/DTLS.read/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.dispose()
+
+    h.assert_true(
+      client.read() is InvalidOperation,
+      "read after dispose should return InvalidOperation")
+    h.assert_true(
+      client.read(10) is InvalidOperation,
+      "read(10) after dispose should return InvalidOperation")
+
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSReceiveAfterDispose is UnitTest
+  """
+  Receiving on a disposed DTLS session returns `InvalidOperation`.
+  """
+  fun name(): String => "net/dtls/DTLS.receive/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.dispose()
+
+    h.assert_true(
+      client.receive("hello") is InvalidOperation,
+      "receive after dispose should return InvalidOperation")
+
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSContextDisposeTwice is UnitTest
+  """
+  Disposing a DTLSContext twice does not crash.
+  """
+  fun name(): String => "net/dtls/DTLSContext.dispose/twice"
+
+  fun apply(h: TestHelper) =>
+    let ctx = DTLSContext
+
+    ctx
+      .> dispose()
+      .dispose()
+
+class \nodoc\ iso _TestDTLSContextClientAfterDispose is UnitTest
+  """
+  `client` on a disposed DTLSContext raises an error rather than handing a null
+  context to `SSL_new`.
+  """
+  fun name(): String => "net/dtls/DTLSContext.client/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let live: DTLSContext val = recover val DTLSContext end
+
+    try
+      live.client()?.dispose()
+    else
+      h.fail("client() on a live context should not raise")
+    end
+
+    let mutable: DTLSContext iso = recover iso DTLSContext end
+    mutable.dispose()
+    let disposed: DTLSContext val = consume mutable
+
+    try
+      disposed.client()?.dispose()
+      h.fail("client() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestDTLSContextServerAfterDispose is UnitTest
+  """
+  `server` on a disposed DTLSContext raises an error rather than handing a null
+  context to `SSL_new`.
+  """
+  fun name(): String => "net/dtls/DTLSContext.server/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let live: DTLSContext val = recover val DTLSContext end
+
+    try
+      live.server()?.dispose()
+    else
+      h.fail("server() on a live context should not raise")
+    end
+
+    let mutable: DTLSContext iso = recover iso DTLSContext end
+    mutable.dispose()
+    let disposed: DTLSContext val = consume mutable
+
+    try
+      disposed.server()?.dispose()
+      h.fail("server() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestDTLSContextSetMinProtoVersionAfterDispose is UnitTest
+  """
+  `set_min_proto_version` on a disposed DTLSContext raises an error rather than
+  passing a null `SSL_CTX*` to `SSL_CTX_ctrl`.
+  """
+  fun name(): String =>
+    "net/dtls/DTLSContext.set_min_proto_version/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = DTLSContext
+
+    try
+      ctx.set_min_proto_version(DTLS1u2Version())?
+    else
+      h.fail("set_min_proto_version() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_min_proto_version(DTLS1u2Version())?
+      h.fail("set_min_proto_version() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestDTLSContextSetMaxProtoVersionAfterDispose is UnitTest
+  """
+  `set_max_proto_version` on a disposed DTLSContext raises an error rather than
+  passing a null `SSL_CTX*` to `SSL_CTX_ctrl`.
+  """
+  fun name(): String =>
+    "net/dtls/DTLSContext.set_max_proto_version/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = DTLSContext
+
+    try
+      ctx.set_max_proto_version(DTLS1u2Version())?
+    else
+      h.fail("set_max_proto_version() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_max_proto_version(DTLS1u2Version())?
+      h.fail("set_max_proto_version() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestDTLSContextSetAuthorityAfterDispose is UnitTest
+  """
+  `set_authority` on a disposed DTLSContext raises an error.
+  """
+  fun name(): String => "net/dtls/DTLSContext.set_authority/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let auth = FileAuth(h.env.root)
+    let ctx = DTLSContext
+
+    try
+      ctx.set_authority(FilePath(auth, "assets/cert.pem"))?
+    else
+      h.fail("set_authority() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_authority(FilePath(auth, "assets/cert.pem"))?
+      h.fail("set_authority() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestDTLSContextSetCertAfterDispose is UnitTest
+  """
+  `set_cert` on a disposed DTLSContext raises an error.
+  """
+  fun name(): String => "net/dtls/DTLSContext.set_cert/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let auth = FileAuth(h.env.root)
+    let cert = FilePath(auth, "assets/cert.pem")
+    let key = FilePath(auth, "assets/key.pem")
+    let ctx = DTLSContext
+
+    try
+      ctx.set_cert(cert, key)?
+    else
+      h.fail("set_cert() on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_cert(cert, key)?
+      h.fail("set_cert() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestDTLSContextSetCiphersAfterDispose is UnitTest
+  """
+  `set_ciphers` on a disposed DTLSContext raises an error.
+  """
+  fun name(): String => "net/dtls/DTLSContext.set_ciphers/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = DTLSContext
+
+    try
+      ctx.set_ciphers("HIGH")?
+    else
+      h.fail("set_ciphers(\"HIGH\") on a live context should not raise")
+    end
+
+    ctx.dispose()
+
+    try
+      ctx.set_ciphers("HIGH")?
+      h.fail("set_ciphers() on a disposed context should raise")
+    end
+
+class \nodoc\ iso _TestDTLSContextSetVerifyDepthAfterDispose is UnitTest
+  """
+  `set_verify_depth` on a disposed DTLSContext does nothing.
+  """
+  fun name(): String => "net/dtls/DTLSContext.set_verify_depth/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = DTLSContext
+
+    ctx.set_verify_depth(4)
+
+    ctx.dispose()
+    ctx.set_verify_depth(4)
+
+    h.assert_false(
+      ctx.alpn_set_client_protocols(["h2"]),
+      "the context should still be disposed")
+
+class \nodoc\ iso _TestDTLSContextALPNSetResolverAfterDispose is UnitTest
+  """
+  `alpn_set_resolver` on a disposed DTLSContext returns `false`.
+  """
+  fun name(): String =>
+    "net/dtls/DTLSContext.alpn_set_resolver/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let resolver = ALPNStandardProtocolResolver(["h2"])
+    let ctx = DTLSContext
+
+    h.assert_true(
+      ctx.alpn_set_resolver(resolver),
+      "alpn_set_resolver() on a live context should return true")
+
+    ctx.dispose()
+
+    h.assert_false(
+      ctx.alpn_set_resolver(resolver),
+      "alpn_set_resolver() on a disposed context should return false")
+
+class \nodoc\ iso _TestDTLSContextALPNSetClientProtocolsAfterDispose
+  is UnitTest
+  """
+  `alpn_set_client_protocols` on a disposed DTLSContext returns `false`.
+  """
+  fun name(): String =>
+    "net/dtls/DTLSContext.alpn_set_client_protocols/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    let ctx = DTLSContext
+
+    h.assert_true(
+      ctx.alpn_set_client_protocols(["h2"]),
+      "alpn_set_client_protocols() on a live context should return true")
+
+    ctx.dispose()
+
+    h.assert_false(
+      ctx.alpn_set_client_protocols(["h2"]),
+      "alpn_set_client_protocols() on a disposed context should return false")
+
+class \nodoc\ iso _TestDTLSWriteAfterDispose is UnitTest
+  """
+  `write` on a disposed DTLS session does nothing and does not raise.
+  """
+  fun name(): String => "net/dtls/DTLS.write/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.dispose()
+
+    try
+      client.write("data")?
+    else
+      h.fail("write() on a disposed session should not raise an error")
+    end
+
+    h.assert_true(
+      client.send() is None,
+      "write() on a disposed session should not queue anything to send")
+
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSSendAfterDisposeReturnsNone is UnitTest
+  """
+  `send` on a disposed DTLS session returns `None` instead of reading a freed
+  BIO.
+
+  The session has encrypted bytes waiting when it is disposed, so `None` here
+  is the disposed check and not an empty BIO.
+  """
+  fun name(): String => "net/dtls/DTLS.send/after_dispose_returns_none"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    try
+      client.write("data")?
+    else
+      h.fail("client could not write application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      client.send() isnt None,
+      "a session that has just written should have bytes to send")
+
+    client.dispose()
+
+    h.assert_true(
+      client.send() is None,
+      "send() on a disposed session should return None")
+
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSReadAfterDisposeWithBufferedFrame is UnitTest
+  """
+  A session holding decrypted bytes from an incomplete `expect` frame returns
+  `InvalidOperation` from `read` once it is disposed, rather than handing
+  those bytes back.
+  """
+  fun name(): String => "net/dtls/DTLS.read/after_dispose_with_buffered_frame"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    try
+      client.write("ab")?
+      _TestDTLSTransfer(client, server)
+    else
+      h.fail("client could not send application data")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      server.read(4) is None,
+      "two bytes should not satisfy read(4)")
+
+    server.dispose()
+
+    h.assert_true(
+      server.read(2) is InvalidOperation,
+      "read(2) on a disposed session should return InvalidOperation, even with"
+        + " two bytes already buffered")
+
+    client.dispose()
+
+class \nodoc\ iso _TestDTLSReadOnAuthFail is UnitTest
+  """
+  `read` on a session that failed authentication returns `SSLError` and does
+  not lose the authentication failure.
+  """
+  fun name(): String => "net/dtls/DTLS.read/on_auth_fail"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server, let cr, _) =
+      try
+        let client_ctx =
+          _TestDTLSContext(h where authority = true, client_verify = true)?
+        let server_ctx = _TestDTLSContext(h where cert = true)?
+        _TestDTLSSessionPair.attempt(
+          h, client_ctx, server_ctx where hostname = "nomatch.example.com")?
+      else
+        h.fail("could not create a DTLS session pair")
+        return
+      end
+
+    h.assert_true(
+      cr is SSLAuthFail,
+      "the client should report SSLAuthFail after a hostname mismatch")
+
+    h.assert_true(
+      client.read() is SSLError,
+      "read() on a failed session should return SSLError")
+
+    h.assert_true(
+      client.read(10) is SSLError,
+      "read(10) on a failed session should return SSLError")
+
+    h.assert_true(
+      client.receive("") is SSLAuthFail,
+      "receive should still report SSLAuthFail after reads")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSReceiveOnAuthFail is UnitTest
+  """
+  `receive` on a session in `SSLAuthFail` does nothing.
+  """
+  fun name(): String => "net/dtls/DTLS.receive/on_auth_fail"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server, let cr, let sr) =
+      try
+        let client_ctx =
+          _TestDTLSContext(h where authority = true, client_verify = true)?
+        let server_ctx = _TestDTLSContext(h where cert = true)?
+        _TestDTLSSessionPair.attempt(
+          h, client_ctx, server_ctx where hostname = "nomatch.example.com")?
+      else
+        h.fail("could not create a DTLS session pair")
+        return
+      end
+
+    h.assert_true(
+      cr is SSLAuthFail,
+      "the client should report SSLAuthFail after a hostname mismatch")
+    h.assert_true(
+      sr is SSLReady,
+      "the server should report SSLReady")
+
+    try
+      server.write("should not be received")?
+      while true do
+        match \exhaustive\ server.send()
+        | let d: Array[U8] iso => client.receive(consume d)
+        | None => break
+        end
+      end
+    else
+      h.fail("server could not produce ciphertext")
+      client.dispose()
+      server.dispose()
+      return
+    end
+
+    h.assert_true(
+      client.read() is SSLError,
+      "data received after auth failure should not be readable")
+
+    h.assert_true(
+      client.receive("") is SSLAuthFail,
+      "the session should still report SSLAuthFail")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSSendOnFailedSession is UnitTest
+  """
+  `send` on a failed session does not crash.
+
+  DTLS does not always queue alert bytes the way TLS does — a hostname
+  mismatch is detected after the handshake succeeds at the TLS layer, so
+  OpenSSL may have no alert to send. The test verifies that `send` is safe
+  to call and returns `None` when there is nothing queued.
+  """
+  fun name(): String => "net/dtls/DTLS.send/on_failed_session"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server, let cr, _) =
+      try
+        let client_ctx =
+          _TestDTLSContext(h where authority = true, client_verify = true)?
+        let server_ctx = _TestDTLSContext(h where cert = true)?
+        _TestDTLSSessionPair.attempt(
+          h, client_ctx, server_ctx where hostname = "nomatch.example.com")?
+      else
+        h.fail("could not create a DTLS session pair")
+        return
+      end
+
+    h.assert_true(
+      cr is SSLAuthFail,
+      "client should report SSLAuthFail")
+
+    // Drain whatever send has — it may be alert bytes or None.
+    while true do
+      match \exhaustive\ client.send()
+      | let _: Array[U8] iso => None
+      | None => break
+      end
+    end
+
+    h.assert_true(
+      client.send() is None,
+      "send should return None once drained")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSCloseFromReady is UnitTest
+  """
+  Calling `close` on a ready session queues a `close_notify` alert in the
+  output BIO.
+  """
+  fun name(): String => "net/dtls/DTLS.close/from_ready"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    h.assert_true(
+      client.send() is None,
+      "nothing queued before close")
+
+    client.close()
+
+    h.assert_true(
+      client.send() isnt None,
+      "close_notify should be queued in the output BIO")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSCloseIdempotent is UnitTest
+  """
+  A second `close` call is a no-op — it produces no additional output.
+  """
+  fun name(): String => "net/dtls/DTLS.close/idempotent"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.close()
+
+    while true do
+      match \exhaustive\ client.send()
+      | let _: Array[U8] iso => None
+      | None => break
+      end
+    end
+
+    client.close()
+
+    h.assert_true(
+      client.send() is None,
+      "second close should produce no additional output")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSCloseFromWrongStates is UnitTest
+  """
+  `close` is a no-op during handshake and after auth failure.
+
+  The SSL equivalent also tests close after SSLError, but DTLS silently drops
+  invalid datagrams per RFC 6347 rather than transitioning to SSLError, so
+  there is no clean way to reach that state from external input.
+  """
+  fun name(): String => "net/dtls/DTLS.close/from_wrong_states"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair.fresh(h)?
+      else
+        h.fail("could not create fresh sessions")
+        return
+      end
+
+    client.close()
+
+    h.assert_true(
+      client.receive("") is SSLAccepted,
+      "close during handshake should leave session still handshaking")
+
+    client.dispose()
+    server.dispose()
+
+    (let auth_client, let auth_server, let acr, _) =
+      try
+        _TestDTLSSessionPair.attempt(
+          h,
+          _TestDTLSContext(h where client_verify = true)?,
+          _TestDTLSContext(h where cert = true)?)?
+      else
+        h.fail("could not create an auth-fail session pair")
+        return
+      end
+
+    h.assert_true(
+      acr is SSLAuthFail,
+      "client should report SSLAuthFail")
+
+    auth_client.close()
+
+    h.assert_true(
+      auth_client.receive("") is SSLAuthFail,
+      "receive should still report SSLAuthFail after close")
+
+    auth_client.dispose()
+    auth_server.dispose()
+
+class \nodoc\ iso _TestDTLSCloseAfterDispose is UnitTest
+  """
+  `close` after `dispose` is a no-op.
+  """
+  fun name(): String => "net/dtls/DTLS.close/after_dispose"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.dispose()
+    client.close()
+
+    h.assert_true(
+      client.send() is None,
+      "close after dispose should not queue anything")
+
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSPeerCloseNotifyDetected is UnitTest
+  """
+  When one session sends `close_notify`, the other detects it via `read` and
+  transitions to `SSLClosed`, not `SSLError`.
+  """
+  fun name(): String => "net/dtls/DTLS.read/peer_close_notify"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.close()
+
+    _TestDTLSTransfer(client, server)
+
+    match \exhaustive\ server.read()
+    | let _: Array[U8] iso =>
+      h.fail("server read produced data from a close_notify")
+    | None =>
+      h.fail("server should report SSLClosed, not None")
+    | SSLClosed => None
+    | SSLError =>
+      h.fail("server should report SSLClosed, not SSLError")
+    | InvalidOperation =>
+      h.fail("server should report SSLClosed, not InvalidOperation")
+    end
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSWriteBlockedInClosed is UnitTest
+  """
+  `write` raises an error in `SSLClosed`.
+  """
+  fun name(): String => "net/dtls/DTLS.write/blocked_in_closed"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.close()
+
+    let write_succeeded =
+      try
+        client.write("should fail")?
+        true
+      else
+        false
+      end
+
+    h.assert_false(
+      write_succeeded,
+      "write should raise an error in SSLClosed")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSBidirectionalCloseRoundtrip is UnitTest
+  """
+  Full bidirectional shutdown: one side calls `close`, the other detects it
+  via `read` and calls `close` in response.
+  """
+  fun name(): String => "net/dtls/DTLS.close/bidirectional_roundtrip"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.close()
+
+    _TestDTLSTransfer(client, server)
+
+    let sr = server.read()
+
+    h.assert_true(
+      sr is SSLClosed,
+      "server should report SSLClosed after receiving client's close_notify")
+
+    server.close()
+
+    _TestDTLSTransfer(server, client)
+
+    let cr = client.read()
+
+    h.assert_true(
+      cr is SSLClosed,
+      "client should report SSLClosed")
+
+    client.dispose()
+    server.dispose()
+
+class \nodoc\ iso _TestDTLSWriteBlockedInClosing is UnitTest
+  """
+  `write` raises an error in `_DTLSClosing`.
+  """
+  fun name(): String => "net/dtls/DTLS.write/blocked_in_closing"
+
+  fun apply(h: TestHelper) =>
+    (let client, let server) =
+      try
+        _TestDTLSSessionPair(h)?
+      else
+        h.fail("could not establish a DTLS session pair")
+        return
+      end
+
+    client.close()
+
+    _TestDTLSTransfer(client, server)
+
+    let sr = server.read()
+
+    h.assert_true(
+      sr is SSLClosed,
+      "server should report SSLClosed after receiving peer's close_notify")
+
+    let write_succeeded =
+      try
+        server.write("should fail")?
+        true
+      else
+        false
+      end
+
+    h.assert_false(
+      write_succeeded,
+      "write should raise an error in _DTLSClosing")
+
+    client.dispose()
+    server.dispose()
+
+

--- a/ssl/net/dtls.pony
+++ b/ssl/net/dtls.pony
@@ -1,0 +1,421 @@
+use "net"
+
+class DTLS
+  """
+  A DTLS session manages handshakes, encryption and decryption. It is not tied
+  to any transport layer.
+
+  DTLS is the datagram variant of TLS. It provides the same authentication and
+  encryption guarantees over unreliable transports like UDP. This type is
+  separate from `SSL` because DTLS and TLS sessions are not interchangeable:
+  a TLS context cannot create a DTLS session and vice versa.
+  """
+  let _hostname: String
+  let _verify: Bool
+  // Nothing reads this. `SSL_new` takes a reference on the `SSL_CTX`, so the
+  // `SSL_CTX` outlives a `DTLSContext` the caller drops while this session is
+  // alive. Holding the context here keeps it, and the ALPN resolver it handed
+  // to OpenSSL, alive for as long as the session can drive a handshake.
+  let _context: DTLSContext
+  var _ssl: Pointer[_SSL] = Pointer[_SSL]
+  var _input: Pointer[_BIO] tag = Pointer[_BIO]
+  var _output: Pointer[_BIO] tag = Pointer[_BIO]
+  var _state: _DTLSSessionState = _DTLSHandshaking
+  var _read_buf: Array[U8] iso = []
+
+  new _create(
+    context: DTLSContext val,
+    server: Bool,
+    verify: Bool,
+    hostname: String = "")
+    ?
+  =>
+    """
+    Create a client or server DTLS session from a context.
+    """
+    let ctx = context._ssl_ctx()
+    if ctx.is_null() then error end
+    _context = context
+    _hostname = hostname
+    _verify = verify
+
+    _ssl = @SSL_new(ctx)
+    if _ssl.is_null() then error end
+
+    let mode = if verify then I32(3) else I32(0) end
+    @SSL_set_verify(_ssl, mode, Pointer[None])
+
+    _input = @BIO_new(@BIO_s_mem())
+    if _input.is_null() then error end
+
+    _output = @BIO_new(@BIO_s_mem())
+    if _output.is_null() then
+      @BIO_free(_input)
+      _input = Pointer[_BIO]
+      error
+    end
+
+    @SSL_set_bio(_ssl, _input, _output)
+
+    if
+      (_hostname.size() > 0)
+        and not DNS.is_ip4(_hostname)
+        and not DNS.is_ip6(_hostname)
+    then
+      // SSL_set_tlsext_host_name
+      @SSL_ctrl(_ssl, 55, 0, _hostname.cstring())
+    end
+
+    if server then
+      @SSL_set_accept_state(_ssl)
+    else
+      @SSL_set_connect_state(_ssl)
+      _kick_handshake()
+    end
+
+  fun box alpn_selected(): (ALPNProtocolName | None) =>
+    """
+    The protocol identifier negotiated via ALPN, or `None` when no protocol
+    has been selected.
+    """
+    _state.alpn_selected(this)
+
+  fun ref close() =>
+    """
+    Send `close_notify` to the peer, initiating an orderly shutdown.
+    After calling this, drain `send` to deliver the encrypted `close_notify`
+    bytes to the transport.
+    """
+    _state.close(this)
+
+  fun ref read(expect: USize = 0): SSLReadResult =>
+    """
+    Returns unencrypted bytes to be passed to the application, `None` when
+    no data is available yet, `SSLClosed` when the peer sent `close_notify`,
+    or `SSLError` on a protocol or I/O error.
+
+    When `expect` is non-zero, buffers internally until at least `expect`
+    bytes are available, then returns everything it holds.
+    """
+    _state.read(this, expect)
+
+  fun ref write(data: ByteSeq) ? =>
+    """
+    Encrypt application data for sending. Raises an error when the session
+    is not ready for application data or when encryption fails.
+    """
+    _state.write(this, data)?
+
+  fun ref receive(data: ByteSeq): SSLReceiveResult =>
+    """
+    Feed encrypted data from the transport into the session.
+
+    Returns what happened: `SSLAccepted` when data was accepted with nothing
+    else to report, `SSLReady` when the handshake completed, `SSLAuthFail`
+    when the peer's certificate was rejected, `SSLError` on failure, or
+    `InvalidOperation` when the session is no longer operational.
+    """
+    _state.receive(this, data)
+
+  fun ref send(): (Array[U8] iso^ | None) =>
+    """
+    Returns encrypted bytes to be passed to the destination, or `None` when
+    there is nothing to send.
+    """
+    _state.send(this)
+
+  fun ref dispose() =>
+    """
+    Dispose of the session.
+    """
+    _state.dispose(this)
+
+  fun _final() =>
+    if not _ssl.is_null() then
+      @SSL_free(_ssl)
+    end
+
+  fun ref _set_state(new_state: _DTLSSessionState) =>
+    _state = new_state
+
+  fun ref _drain_read_buf(expect: USize): (Array[U8] iso^ | None) =>
+    if (expect > 0) and (_read_buf.size() >= expect) then
+      return _read_buf = []
+    end
+    None
+
+  fun ref _do_receive(data: ByteSeq) =>
+    let total = data.size()
+    if total > 0 then
+      let max_chunk = I32.max_value().usize()
+      var offset: USize = 0
+      while offset < total do
+        let chunk = (total - offset).min(max_chunk)
+        @BIO_write(_input, data.cpointer(offset), chunk.i32())
+        offset = offset + chunk
+      end
+    end
+
+  fun ref _kick_handshake(): SSLReceiveResult =>
+    @ERR_clear_error()
+    let r = @SSL_do_handshake(_ssl)
+
+    if r > 0 then
+      _verify_hostname()
+    else
+      match @SSL_get_error(_ssl, r)
+      | _SSLErrorCode.ssl() | _SSLErrorCode.syscall() =>
+        if _peer_auth_failed() then
+          _state = _DTLSAuthFailed
+          SSLAuthFail
+        else
+          _state = _DTLSErrored
+          SSLError
+        end
+      | _SSLErrorCode.zero_return() =>
+        _state = _DTLSErrored
+        SSLError
+      | _SSLErrorCode.want_read() =>
+        SSLAccepted
+      else
+        _Unreachable()
+        SSLError
+      end
+    end
+
+  fun ref _do_read(expect: USize): SSLReadResult =>
+    let offset = _read_buf.size()
+
+    var len =
+      if expect > 0 then
+        if offset >= expect then
+          return _read_buf = []
+        end
+
+        expect - offset
+      else
+        1024
+      end
+
+    let pending = @SSL_pending(_ssl).usize()
+
+    if pending > 0 then
+      len = if expect > 0 then len.min(pending) else pending end
+    end
+
+    len = len.min(I32.max_value().usize())
+    _read_buf.undefined(offset + len)
+    @ERR_clear_error()
+    let r = @SSL_read(_ssl, _read_buf.cpointer(offset), len.i32())
+
+    let filled = if r > 0 then r.usize() else 0 end
+    _read_buf.truncate(offset + filled)
+
+    if r <= 0 then
+      match @SSL_get_error(_ssl, r)
+      | _SSLErrorCode.ssl()
+      | _SSLErrorCode.syscall() =>
+        _state = _DTLSErrored
+        return SSLError
+      | _SSLErrorCode.zero_return() =>
+        _state = _DTLSClosing
+        if _read_buf.size() > 0 then
+          return _read_buf = []
+        end
+        return SSLClosed
+      | _SSLErrorCode.want_read() =>
+        return None
+      else
+        _Unreachable()
+        return None
+      end
+    end
+
+    let ready =
+      if expect == 0 then
+        _read_buf.size() > 0
+      else
+        _read_buf.size() == expect
+      end
+
+    if ready then
+      _read_buf = []
+    else
+      ifdef "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" then
+        if @BIO_ctrl_pending(_input) > 0 then
+          _do_read(expect)
+        elseif @SSL_has_pending(_ssl) == 1 then
+          _do_read(expect)
+        end
+      elseif "libressl" then
+        if @BIO_ctrl_pending(_input) > 0 then
+          _do_read(expect)
+        end
+      else
+        compile_error "You must select an SSL version to use."
+      end
+    end
+
+  fun ref _do_write(data: ByteSeq) ? =>
+    let total = data.size()
+    if total > 0 then
+      let max_chunk = I32.max_value().usize()
+      var offset: USize = 0
+      while offset < total do
+        let chunk = (total - offset).min(max_chunk)
+        @ERR_clear_error()
+        let r = @SSL_write(_ssl, data.cpointer(offset), chunk.i32())
+        if r <= 0 then
+          match @SSL_get_error(_ssl, r)
+          | _SSLErrorCode.ssl()
+          | _SSLErrorCode.syscall() =>
+            _state = _DTLSErrored
+          | _SSLErrorCode.zero_return() =>
+            _state = _DTLSClosing
+          | _SSLErrorCode.want_read() =>
+            None
+          else
+            _Unreachable()
+          end
+          error
+        end
+        offset = offset + chunk
+      end
+    end
+
+  fun ref _do_close_notify() =>
+    @ERR_clear_error()
+    let r = @SSL_shutdown(_ssl)
+    if r < 0 then
+      let err = @SSL_get_error(_ssl, r)
+      if (err == _SSLErrorCode.ssl()) or (err == _SSLErrorCode.syscall()) then
+        _state = _DTLSErrored
+        return
+      else
+        _Unreachable()
+      end
+    end
+    _state = _DTLSClosed
+
+  fun ref _do_send(): (Array[U8] iso^ | None) =>
+    let pending = @BIO_ctrl_pending(_output)
+    if pending == 0 then return None end
+
+    let len = pending.min(I32.max_value().usize())
+    let buf = recover Array[U8] .> undefined(len) end
+    let r = @BIO_read(_output, buf.cpointer(), len.i32())
+    if r <= 0 then return None end
+    buf.truncate(r.usize())
+    buf
+
+  fun box _do_alpn_selected(): (ALPNProtocolName | None) =>
+    var ptr: Pointer[U8] iso = recover Pointer[U8] end
+    var len = U32(0)
+    ifdef
+      "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+    then
+      @SSL_get0_alpn_selected(_ssl, addressof ptr, addressof len)
+    else
+      compile_error "You must select an SSL version to use."
+    end
+
+    if ptr.is_null() then None
+    else
+      recover val String.copy_cpointer(consume ptr, USize.from[U32](len)) end
+    end
+
+  fun ref _do_dispose() =>
+    if not _ssl.is_null() then
+      @SSL_free(_ssl)
+      _ssl = Pointer[_SSL]
+      _input = Pointer[_BIO]
+      _output = Pointer[_BIO]
+    end
+
+  fun ref _peer_auth_failed(): Bool =>
+    """
+    Whether the handshake failure the caller just got from `SSL_do_handshake`
+    was this session rejecting its peer's certificate.
+
+    True for a chain that did not verify, for a peer that sent no certificate
+    when one was required, and for a peer that presented a certificate but
+    could not prove it holds the matching key. False for a peer whose
+    certificate would not parse: the failure happens before chain verification,
+    so it is not distinguishable from one that had nothing to do with a
+    certificate.
+
+    Called for both `SSL_ERROR_SSL` and `SSL_ERROR_SYSCALL`. A callback that
+    runs inside `SSL_do_handshake` can push an entry onto the thread's error
+    queue, changing `SSL_get_error` from one to the other without changing what
+    actually failed. Routing both through this method keeps the reported state
+    consistent.
+
+    Callers must have checked that `_ssl` is not null, and must arrive with the
+    thread's error queue as `SSL_do_handshake` left it. A peer that sent no
+    certificate leaves its reason only on that queue, so an OpenSSL call that
+    clears the queue in between loses it and this returns false.
+    """
+    if not _verify then return false end
+
+    if @SSL_get_verify_result(_ssl) != _X509VerifyResult.ok() then
+      return true
+    end
+
+    var code = @ERR_get_error()
+    while code != 0 do
+      if
+        (_ERRLibrary.of(code) == _ERRLibrary.ssl())
+          and (_ERRReason.of(code)
+            == _ERRReason.peer_did_not_return_a_certificate())
+      then
+        return true
+      end
+      code = @ERR_get_error()
+    end
+
+    let cert =
+      ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+        @SSL_get1_peer_certificate(_ssl)
+      elseif "openssl_1.1.x" or "libressl" then
+        @SSL_get_peer_certificate(_ssl)
+      else
+        compile_error "You must select an SSL version to use."
+      end
+
+    if not cert.is_null() then
+      @X509_free(cert)
+      return true
+    end
+
+    false
+
+  fun ref _verify_hostname(): SSLReceiveResult =>
+    if _verify and (_hostname.size() > 0) then
+      let cert =
+        ifdef "openssl_3.0.x" or "openssl_4.0.x" then
+          @SSL_get1_peer_certificate(_ssl)
+        elseif "openssl_1.1.x" or "libressl" then
+          @SSL_get_peer_certificate(_ssl)
+        else
+          compile_error "You must select an SSL version to use."
+        end
+      let ok = X509.valid_for_host(cert, _hostname)
+
+      if not cert.is_null() then
+        @X509_free(cert)
+      end
+
+      if not ok then
+        _state = _DTLSAuthFailed
+        return SSLAuthFail
+      end
+    end
+
+    _state = _DTLSReady
+    SSLReady
+
+  fun ref _restore_closed_unless_errored(closed: _DTLSClosed) =>
+    match _state
+    | let _: _DTLSErrored => None
+    else _state = closed
+    end

--- a/ssl/net/dtls_context.pony
+++ b/ssl/net/dtls_context.pony
@@ -1,0 +1,337 @@
+use "files"
+
+use @DTLS_method[Pointer[_SSLMethod]]()
+  if "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+
+class val DTLSContext
+  """
+  A DTLS context is used to create DTLS sessions.
+
+  DTLS is the datagram variant of TLS. It provides the same authentication and
+  encryption guarantees over unreliable transports like UDP. A DTLS context uses
+  `DTLS_method()` internally and accepts only DTLS version numbers.
+
+  This type is separate from `SSLContext` because DTLS and TLS are not
+  interchangeable: a TLS context cannot create a DTLS session and vice versa.
+  Keeping them separate makes the wrong combination a compile error.
+  """
+  var _ctx: Pointer[_SSLContext] tag
+  var _client_verify: Bool = true
+  var _server_verify: Bool = false
+  var _alpn_resolver: (ALPNProtocolResolver val | None) = None
+
+  new create() =>
+    """
+    Create a DTLS context.
+    """
+    ifdef
+      "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+    then
+      _ctx = @SSL_CTX_new(@DTLS_method())
+
+      try
+        set_min_proto_version(DTLS1u2Version())?
+        set_max_proto_version(SSLAutoVersion())?
+      end
+    else
+      compile_error "You must select an SSL version to use."
+    end
+
+  fun _ssl_ctx(): Pointer[_SSLContext] tag =>
+    _ctx
+
+  fun val client(hostname: String = ""): DTLS iso^ ? =>
+    """
+    Create a client-side DTLS session. If a hostname is supplied and client
+    verification is on, the server side certificate must be valid for that
+    hostname. Raises an error if the context has been disposed.
+
+    The session holds the context, so the context lives for as long as the
+    session can handshake.
+    """
+    let verify = _client_verify
+    recover DTLS._create(this, false, verify, hostname)? end
+
+  fun val server(): DTLS iso^ ? =>
+    """
+    Create a server-side DTLS session. Raises an error if the context has been
+    disposed.
+
+    The session holds the context, so the context and the ALPN resolver it
+    installed with OpenSSL live for as long as the session can handshake.
+    """
+    let verify = _server_verify
+    recover DTLS._create(this, true, verify)? end
+
+  fun ref set_cert(cert: FilePath, key: FilePath) ? =>
+    """
+    The cert file is a PEM certificate chain. The key file is a private key.
+    Servers must set this. For clients, it is optional. Raises an error if the
+    context has been disposed.
+    """
+    if _ctx.is_null() then error end
+
+    if
+      (cert.path.size() == 0)
+        or (key.path.size() == 0)
+        or (0 == @SSL_CTX_use_certificate_chain_file(
+          _ctx, cert.path.cstring()))
+        or (0 == @SSL_CTX_use_PrivateKey_file(
+          _ctx, key.path.cstring(), I32(1)))
+        or (0 == @SSL_CTX_check_private_key(_ctx))
+    then
+      error
+    end
+
+  fun ref set_authority(
+    file: (FilePath | None),
+    path: (FilePath | None) = None)
+    ?
+  =>
+    """
+    Use a PEM file and/or a directory of PEM files to specify certificate
+    authorities. Clients must set this. For servers, it is optional. Use None
+    to indicate no file or no path. Raises an error if these verify locations
+    aren't valid, or if the context has been disposed.
+
+    If both `file` and `path` are `None`, on Windows this method loads the
+    system root certificates. On Posix it raises an error.
+    """
+    if _ctx.is_null() then error end
+
+    if (file is None) and (path is None) then
+      ifdef windows then
+        _load_windows_root_certs()?
+      else
+        error
+      end
+    else
+      let fs = try (file as FilePath).path else "" end
+      let ps = try (path as FilePath).path else "" end
+
+      let f = if fs.size() > 0 then fs.cstring() else Pointer[U8] end
+      let p = if ps.size() > 0 then ps.cstring() else Pointer[U8] end
+
+      if
+        (f.is_null() and p.is_null())
+          or (0 == @SSL_CTX_load_verify_locations(_ctx, f, p))
+      then
+        error
+      end
+    end
+
+  fun ref _load_windows_root_certs() ? =>
+    ifdef windows then
+      let root_str = "ROOT"
+      let h_store = @CertOpenSystemStoreA(Pointer[None], root_str.cstring())
+      if h_store.is_null() then error end
+
+      let x509_store = @X509_STORE_new()
+      if x509_store.is_null() then
+        @CertCloseStore(h_store, U32(0))
+        error
+      end
+
+      var p_context =
+        @CertEnumCertificatesInStore(
+          h_store, NullablePointer[_CertContext].none())
+
+      try
+        while true do
+          let cert_context = try p_context()? else break end
+          let x509 =
+            @d2i_X509(
+              Pointer[Pointer[X509]],
+              addressof cert_context.pb_cert_encoded,
+              cert_context.cb_cert_encoded.ilong())
+          if not x509.is_null() then
+            let result = @X509_STORE_add_cert(x509_store, x509)
+            @X509_free(x509)
+            if result != 1 then error end
+          end
+
+          p_context = @CertEnumCertificatesInStore(h_store, p_context)
+        end
+
+        @SSL_CTX_set_cert_store(_ctx, x509_store)
+      else
+        if not p_context.is_none() then
+          @CertFreeCertificateContext(p_context)
+        end
+        @X509_STORE_free(x509_store)
+      then
+        @CertCloseStore(h_store, U32(0))
+      end
+    end
+
+  fun ref set_ciphers(ciphers: String) ? =>
+    """
+    Set the accepted ciphers. This replaces the existing list. Raises an error
+    if the cipher list is invalid, or if the context has been disposed.
+    """
+    if _ctx.is_null() then error end
+
+    if 0 == @SSL_CTX_set_cipher_list(_ctx, ciphers.cstring()) then
+      error
+    end
+
+  fun ref set_client_verify(state: Bool) =>
+    """
+    Set to true to require verification. Defaults to true.
+
+    A client session created with `state` false never reports `SSLAuthFail`.
+    """
+    _client_verify = state
+
+  fun ref set_server_verify(state: Bool) =>
+    """
+    Set to true to require verification. Defaults to false.
+
+    A server session created with `state` false never reports `SSLAuthFail`.
+    It sends no certificate request, so it has no peer identity to reject.
+    """
+    _server_verify = state
+
+  fun ref set_verify_depth(depth: U32) =>
+    """
+    Set the verify depth. Defaults to 6. Does nothing if the context has been
+    disposed.
+
+    A depth of 2^31 or more arrives at the SSL library as a negative depth.
+    What each backend does with one is undocumented, so do not use a depth that
+    large.
+    """
+    if not _ctx.is_null() then
+      @SSL_CTX_set_verify_depth(_ctx, depth.i32())
+    end
+
+  fun ref set_min_proto_version(version: ULong) ? =>
+    """
+    Set minimum protocol version. Set to SSLAutoVersion, 0, to automatically
+    manage lowest version.
+
+    Raises an error if the context has been disposed or if the SSL library
+    rejects the version.
+
+    Supported versions: DTLS1Version, DTLS1u2Version
+    """
+    if _ctx.is_null() then error end
+
+    let result =
+      @SSL_CTX_ctrl(
+        _ctx, _SSLCtrlSetMinProtoVersion(), version.ilong(), Pointer[None])
+    if result == 0 then
+      error
+    end
+
+  fun get_min_proto_version(): ILong =>
+    """
+    Get minimum protocol version. Returns SSLAutoVersion, 0,
+    when automatically managing lowest version. A disposed context returns
+    SSLAutoVersion.
+
+    Supported versions: DTLS1Version, DTLS1u2Version
+    """
+    if _ctx.is_null() then return SSLAutoVersion().ilong() end
+
+    @SSL_CTX_ctrl(_ctx, _SSLCtrlGetMinProtoVersion(), 0, Pointer[None])
+
+  fun ref set_max_proto_version(version: ULong) ? =>
+    """
+    Set maximum protocol version. Set to SSLAutoVersion, 0, to automatically
+    manage highest version.
+
+    Raises an error if the context has been disposed or if the SSL library
+    rejects the version.
+
+    Supported versions: DTLS1Version, DTLS1u2Version
+    """
+    if _ctx.is_null() then error end
+
+    let result =
+      @SSL_CTX_ctrl(
+        _ctx, _SSLCtrlSetMaxProtoVersion(), version.ilong(), Pointer[None])
+    if result == 0 then
+      error
+    end
+
+  fun get_max_proto_version(): ILong =>
+    """
+    Get maximum protocol version. Returns SSLAutoVersion, 0,
+    when automatically managing highest version. A disposed context returns
+    SSLAutoVersion.
+
+    Supported versions: DTLS1Version, DTLS1u2Version
+    """
+    if _ctx.is_null() then return SSLAutoVersion().ilong() end
+
+    @SSL_CTX_ctrl(_ctx, _SSLCtrlGetMaxProtoVersion(), 0, Pointer[None])
+
+  fun ref alpn_set_resolver(resolver: ALPNProtocolResolver val): Bool =>
+    """
+    Use `resolver` to choose the protocol to be selected for incoming
+    connections.
+
+    OpenSSL holds a raw pointer to `resolver` that the Pony garbage collector
+    cannot see. The context keeps `resolver` alive, and every session made from
+    the context keeps the context alive, so `resolver` lives for as long as any
+    session that can reach it. The resolver has to be set before any session is
+    created, which the capabilities enforce: this method needs a mutable
+    context, and `client` and `server` need one that has been made immutable.
+
+    Returns true on success. Returns false if the context has been disposed.
+    """
+    if _ctx.is_null() then return false end
+
+    ifdef
+      "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+    then
+      _alpn_resolver = resolver
+      @SSL_CTX_set_alpn_select_cb(
+        _ctx, addressof SSLContext._alpn_select_cb, resolver)
+      return true
+    else
+      compile_error "You must select an SSL version to use."
+    end
+
+  fun ref alpn_set_client_protocols(protocols: Array[String] box): Bool =>
+    """
+    Advertise the protocol names in `protocols` when connecting to a server.
+    Each name must be between 1 and 255 bytes.
+
+    Returns true on success. Returns false if the context has been disposed,
+    if `protocols` is empty or holds a name of an unusable size, or if OpenSSL
+    would not take the list.
+    """
+    if _ctx.is_null() then return false end
+
+    ifdef
+      "openssl_1.1.x" or "openssl_3.0.x" or "openssl_4.0.x" or "libressl"
+    then
+      try
+        let proto_list = _ALPNProtocolList.from_array(protocols)?
+        let result =
+          @SSL_CTX_set_alpn_protos(
+            _ctx, proto_list.cpointer(), proto_list.size().u32())
+        return result == 0
+      end
+    else
+      compile_error "You must select an SSL version to use."
+    end
+
+    false
+
+  fun ref dispose() =>
+    """
+    Free the DTLS context. A disposed context cannot create a session, and no
+    configuration of it can take effect.
+    """
+    if not _ctx.is_null() then
+      @SSL_CTX_free(_ctx)
+      _ctx = Pointer[_SSLContext]
+    end
+
+  fun _final() =>
+    if not _ctx.is_null() then
+      @SSL_CTX_free(_ctx)
+    end

--- a/ssl/net/ssl_context.pony
+++ b/ssl/net/ssl_context.pony
@@ -341,8 +341,7 @@ class val SSLContext
     the current maximum, or if the SSL library rejects the version.
 
     Supported versions: SSL3Version, TLS1Version, TLS1u1Version,
-                        TLS1u2Version, TLS1u3Version, DTLS1Version,
-                        DTLS1u2Version
+                        TLS1u2Version, TLS1u3Version
     """
     if _ctx.is_null() then error end
 
@@ -366,8 +365,7 @@ class val SSLContext
     SSLAutoVersion.
 
     Supported versions: SSL3Version, TLS1Version, TLS1u1Version,
-                        TLS1u2Version, TLS1u3Version, DTLS1Version,
-                        DTLS1u2Version
+                        TLS1u2Version, TLS1u3Version
     """
     if _ctx.is_null() then return SSLAutoVersion().ilong() end
 
@@ -382,8 +380,7 @@ class val SSLContext
     the current minimum, or if the SSL library rejects the version.
 
     Supported versions: SSL3Version, TLS1Version, TLS1u1Version,
-                        TLS1u2Version, TLS1u3Version, DTLS1Version,
-                        DTLS1u2Version
+                        TLS1u2Version, TLS1u3Version
     """
     if _ctx.is_null() then error end
 
@@ -407,8 +404,7 @@ class val SSLContext
     SSLAutoVersion.
 
     Supported versions: SSL3Version, TLS1Version, TLS1u1Version,
-                        TLS1u2Version, TLS1u3Version, DTLS1Version,
-                        DTLS1u2Version
+                        TLS1u2Version, TLS1u3Version
     """
     if _ctx.is_null() then return SSLAutoVersion().ilong() end
 


### PR DESCRIPTION
`DTLSContext` and `DTLS` bring DTLS (datagram TLS) support. DTLS provides the same authentication and encryption as TLS over unreliable transports like UDP.

The API mirrors `SSLContext` and `SSL`. A `DTLSContext` creates client or server `DTLS` sessions; the session encrypts and decrypts application data through `write`, `read`, `receive`, and `send`, with the same return types (`SSLReceiveResult`, `SSLReadResult`).

Separate types rather than shared ones because a TLS context cannot create a DTLS session and vice versa — using separate types makes the wrong combination a compile error. This was the key design decision from the earlier session on #143.

One behavioral difference from TLS worth noting: DTLS silently drops invalid datagrams per RFC 6347 rather than reporting `SSLError`. Tests that rely on garbage bytes producing errors were adapted or removed accordingly.

Closes #143
