### PR TITLE
Use make lint in pony-lint workflow

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -21,4 +21,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint
-        run: pony-lint
+        run: make lint


### PR DESCRIPTION
Matches the convention used in other ponylang projects — the Makefile lint target handles dependency fetching when needed.