### PR TITLE
Add nightly-lint job to the breakage workflow

### DIFF
--- a/.github/workflows/breakage-against-linux-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-linux-ponyc-latest.yml
@@ -9,6 +9,27 @@ permissions:
   packages: read
 
 jobs:
+  pony-lint:
+    name: Lint against ponyc main
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.9.2:nightly
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   test-libressl-3-vs-ponyc-latest:
     name: LibreSSL 3.x with ponyc main
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the missing `pony-lint` job to `breakage-against-linux-ponyc-latest.yml` so a shared-docker update that lands a new pony-lint rule surfaces here. ssl itself has no lint or build changes.